### PR TITLE
Place banner ad between translated output and input

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -51,6 +51,11 @@ struct TranslationScreen: View {
                     .padding(.top, 20)
                 }
                 
+                // Advertisement Banner Placeholder
+                BannerAdSwiftUIView()
+                    .frame(height: 50)
+//                    .cornerRadius(8)
+
                 // Native Input Section
                 TranslationInputView(
                     text: $viewModel.nativeText,
@@ -67,11 +72,6 @@ struct TranslationScreen: View {
                     maxLength: 100
                 )
                 .padding(.horizontal, 16)
-                
-                // Advertisement Banner Placeholder
-                BannerAdSwiftUIView()
-                    .frame(height: 50)
-//                    .cornerRadius(8)
                 
                 // Action Buttons
                 HStack(spacing: 12) {


### PR DESCRIPTION
Repositioned banner to appear between TranslationOutputView and
TranslationInputView for better visual separation of content areas.

# Result
<img width="606" alt="Screenshot 2026-02-02 at 5 23 15 PM" src="https://github.com/user-attachments/assets/faea0741-50f0-4019-95f0-06cab0384edd" />

Resolves #18

🤖 Generated with [Claude Code](https://claude.ai/code)