### PR TITLE
fix: remove unused `isTest` variable in App.swift

### DIFF
--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -82,8 +82,6 @@ struct SendadvApp: App {
 
             guard !SwiftUIAdManager.isDisabled else { return }
 
-            let isTest = adManager.isTesting(unit: .launch)
-
             await adManager.show(unit: .launch)
         }
     }


### PR DESCRIPTION
Removes the unused `let isTest` declaration that produced the compiler warning: "Initialization of immutable value 'isTest' was never used".

Fixes #28

Generated with [Claude Code](https://claude.ai/code)