### PR TITLE
fix: set deploymentTargets iOS 18.0 on DynamicThirdParty and ThirdParty

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -12,6 +12,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: .appBundleId.appending(".thirdparty.dynamic"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "FirebaseCrashlytics", type: .runtime),
                            .package(product: "FirebaseAnalytics", type: .runtime),
                            .package(product: "FirebaseMessaging", type: .runtime),

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -18,6 +18,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: .appBundleId.appending(".thirdparty"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "LSExtensions", type: .runtime),
                            .package(product: "Material", type: .runtime),
                            .package(product: "RxSwift", type: .runtime),


### PR DESCRIPTION
Without an explicit deploymentTargets, Tuist lets Xcode pick the SDK default (iOS 26.x on Xcode 26). The resulting dylibs are tagged with that higher minimum, which causes the linker warning when the App target (iOS 18.0) links against them.

Fixes #30

Generated with [Claude Code](https://claude.ai/code)