### PR TITLE
feat: add auto full-screen mode for landscape orientation

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -46,7 +46,11 @@ struct TranslationScreen: View {
 						onLocaleChange: { locale in
 							viewModel.updateTranslatedLocale(locale)
 						},
-						isFullScreen: $viewModel.isFullScreen
+						isFullScreen: viewModel.isFullScreen,
+						onToggleFullScreen: {
+							viewModel.toggleFullScreen()
+						},
+						deviceOrientation: viewModel.deviceOrientation
 					)
 					.padding(16)
 					
@@ -66,7 +70,11 @@ struct TranslationScreen: View {
 							onLocaleChange: { locale in
 								viewModel.updateTranslatedLocale(locale)
 							},
-							isFullScreen: $viewModel.isFullScreen
+							isFullScreen: viewModel.isFullScreen,
+						onToggleFullScreen: {
+							viewModel.toggleFullScreen()
+						},
+							deviceOrientation: viewModel.deviceOrientation
 						)
 						.padding(.horizontal, 16)
 						.padding(.top, 20)

--- a/Projects/App/Sources/ViewModels/TranslationViewModel.swift
+++ b/Projects/App/Sources/ViewModels/TranslationViewModel.swift
@@ -111,12 +111,14 @@ class TranslationViewModel: ObservableObject {
 		// Auto-toggle full screen only if user hasn't manually toggled
 		guard !manualFullScreenToggle else { return }
 
-		// Switch to full screen in landscape, normal mode in portrait
-		let shouldBeFullScreen = newOrientation.isLandscape
+		// On iPhone, switch to full screen in landscape, normal mode in portrait
+		if UIDevice.current.userInterfaceIdiom == .phone {
+			let shouldBeFullScreen = newOrientation.isLandscape
 
-		if shouldBeFullScreen != isFullScreen {
-			withAnimation(.easeInOut(duration: 0.3)) {
-				isFullScreen = shouldBeFullScreen
+			if shouldBeFullScreen != isFullScreen {
+				withAnimation(.easeInOut(duration: 0.3)) {
+					isFullScreen = shouldBeFullScreen
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Implements automatic switching to full-screen mode when iPhone is rotated to landscape orientation, making it easier to show long translated sentences to others.

## Key Changes
- Added device orientation observer in TranslationViewModel
- Auto-toggle full-screen when rotating to landscape (left or right)
- Auto-exit full-screen when rotating back to portrait
- Respects manual full-screen toggle (disables auto-behavior if user manually toggles)
- Added UIDeviceOrientation extension for orientation validation

## Result
<img width="2622" height="1206" alt="Screenshot 2026-02-10 at 3 06 37 PM" src="https://github.com/user-attachments/assets/87a044b5-c80a-4599-9843-bcf79c0be827" />

Fixes #45

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/2sem/talktrans/actions/runs/21849585547) • [Branch](https://github.com/2sem/talktrans/tree/claude/issue-45-20260210-0242