### PR TITLE
fix: replace deprecated requestRecordPermission with AVAudioApplication API

### DIFF
--- a/Projects/App/Sources/ViewModels/SpeechRecognitionViewModel.swift
+++ b/Projects/App/Sources/ViewModels/SpeechRecognitionViewModel.swift
@@ -43,16 +43,13 @@ class SpeechRecognitionViewModel: ObservableObject {
 				}
 				
 				// Request microphone permission
-				AVAudioSession.sharedInstance().requestRecordPermission { granted in
-					Task { @MainActor in
-						guard granted else {
-							self?.errorMessage = "Microphone permission denied"
-							return
-						}
-						
-						self?.performRecognition(locale: locale, onResult: onResult)
-					}
+				let granted = await AVAudioApplication.requestRecordPermission()
+				guard granted else {
+					self?.errorMessage = "Microphone permission denied"
+					return
 				}
+
+				self?.performRecognition(locale: locale, onResult: onResult)
 			}
 		}
 	}


### PR DESCRIPTION
Replaces the deprecated `AVAudioSession.sharedInstance().requestRecordPermission` (deprecated in iOS 17.0) with the modern async `AVAudioApplication.requestRecordPermission()` API.

Closes #50

Generated with [Claude Code](https://claude.ai/code)