### PR TITLE
fix: add AccentColor to asset catalog

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/Colors/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/Colors/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.918",
+          "green" : "0.200",
+          "red" : "0.576"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.965",
+          "green" : "0.957",
+          "red" : "0.953"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Adds standard iOS AccentColor colorset to resolve the Xcode warning "Accent color 'AccentColor' is not present in any asset catalogs."

The AccentColor uses the same values as the existing AccentPrimary color (#9333EA purple in light mode, #F3F4F5 in dark mode).

Closes #54

Generated with [Claude Code](https://claude.ai/code)