### PR TITLE
feat: migrate to Tuist registry

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,31 +1,36 @@
 {
-  "originHash" : "1e01894271d03b6129c35b625341ca151355ee2faf1c0bd7d401e36dd57ce8f6",
+  "originHash" : "c3ac2645bcaf090c9d2ea6d74e2618c26d3910d84005d45952c5bffc6da92ffa",
   "pins" : [
     {
-      "identity" : "abseil-cpp-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "identity" : "apple.swift-protobuf",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
-        "version" : "1.2024072200.0"
+        "version" : "1.35.1"
       }
     },
     {
-      "identity" : "app-check",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/app-check.git",
+      "identity" : "firebase.firebase-ios-sdk",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
-      }
-    },
-    {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk",
-      "state" : {
-        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
         "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "firebase.leveldb",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "firebase.nanopb",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "2.30910.0"
       }
     },
     {
@@ -38,75 +43,99 @@
       }
     },
     {
-      "identity" : "google-ads-on-device-conversion-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "identity" : "google.abseil-cpp-binary",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
-        "version" : "2.3.0"
+        "version" : "1.2024072200.0"
       }
     },
     {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "identity" : "google.app-check",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "google.googleappmeasurement",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
         "version" : "11.15.0"
       }
     },
     {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "identity" : "google.googledatatransport",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
         "version" : "10.1.0"
       }
     },
     {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
+      "identity" : "google.googleutilities",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
         "version" : "8.1.0"
       }
     },
     {
-      "identity" : "grpc-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
+      "identity" : "google.grpc-binary",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
         "version" : "1.69.1"
       }
     },
     {
-      "identity" : "gtm-session-fetcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "identity" : "google.gtm-session-fetcher",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
         "version" : "4.5.0"
       }
     },
     {
-      "identity" : "interop-ios-for-google-sdks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "identity" : "google.interop-ios-for-google-sdks",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
         "version" : "101.0.0"
       }
     },
     {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
+      "identity" : "google.promises",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
-        "version" : "1.22.5"
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "googleads.google-ads-on-device-conversion-ios-sdk",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleads.swift-package-manager-google-mobile-ads",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "googleads.swift-package-manager-google-user-messaging-platform",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "3.1.0"
       }
     },
     {
@@ -137,57 +166,11 @@
       }
     },
     {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
+      "identity" : "reactivex.RxSwift",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
-      }
-    },
-    {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
-      }
-    },
-    {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "cec68169a048a079f461ba203fe85636548d7a89",
         "version" : "5.1.3"
-      }
-    },
-    {
-      "identity" : "swift-package-manager-google-mobile-ads",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
-      "state" : {
-        "revision" : "1239c23464503053c17d37ee5daa70de3455e9c8",
-        "version" : "12.14.0"
-      }
-    },
-    {
-      "identity" : "swift-package-manager-google-user-messaging-platform",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
-      "state" : {
-        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
-        "version" : "3.1.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
-        "version" : "1.33.3"
       }
     }
   ],

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -103,3 +103,16 @@ default_modes:
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
 fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -3,8 +3,7 @@ import ProjectDescriptionHelpers
 
 let project = Project(
     name: "DynamicThirdParty",
-    packages: [.remote(url: "https://github.com/firebase/firebase-ios-sdk",
-                       requirement: .upToNextMajor(from: "11.8.1")),
+    packages: [.package(id: "firebase.firebase-ios-sdk", from: "11.8.1"),
     ],
     targets: [
         .target(

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -8,8 +8,7 @@ let project = Project(
                 requirement: .exact("0.1.22")),
         .remote(url: "https://github.com/CosmicMind/Material",
                 requirement: .upToNextMajor(from: "3.1.8")),
-        .remote(url: "https://github.com/ReactiveX/RxSwift",
-                requirement: .upToNextMajor(from: "5.1.3")),
+        .package(id: "reactivex.RxSwift", from: "5.1.3"),
 //        .local(path: "../../../../../spms/DownPicker")
     ],
     targets: [

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -7,7 +7,8 @@ let tuist = Tuist(
 //                    swiftVersion: "",
 //                    plugins: <#T##[PluginLocation]#>,
         generationOptions: .options(
-            enableCaching: true
+            enableCaching: true,
+            registryEnabled: true
         ),
 //                    installOptions: <#T##Tuist.InstallOptions#>)
     )


### PR DESCRIPTION
## Summary

- Enable Tuist registry via `registryEnabled: true` in `Tuist.swift`
- Migrate `ReactiveX/RxSwift` → `reactivex.RxSwift` (registry)
- Migrate `firebase/firebase-ios-sdk` → `firebase.firebase-ios-sdk` (registry)
- `2sem/GADManager`, `2sem/LSExtensions`, `CosmicMind/Material` not found on registry — kept as `.remote(url:)`

## Test plan

- [x] `tuist generate --no-open` succeeds cleanly
- [x] Package resolution completes without errors
- [ ] Build and run on device/simulator to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)