### PR TITLE
refactor: extract WatchAdButton into its own view

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -154,22 +154,12 @@ struct TranslationScreen: View {
 						.buttonStyle(.plain)
 
 						// Watch Ad Button (hidden when ad-free)
-						if !isAdFree {
-							WatchAdButton {
-								adManager.showRewarded { rewarded in
-									guard rewarded else { return }
-									LSDefaults.activateAdFree()
-									withAnimation(.easeInOut(duration: 0.25)) {
-										isAdFree = true
-									}
-									showAdFreeToast = true
-									Task {
-										try? await Task.sleep(for: .seconds(2))
-										showAdFreeToast = false
-									}
-								}
+						WatchAdButton(isAdFree: $isAdFree) {
+							showAdFreeToast = true
+							Task {
+								try? await Task.sleep(for: .seconds(2))
+								showAdFreeToast = false
 							}
-							.transition(.opacity.combined(with: .scale(scale: 0.8)))
 						}
 					}
 					.padding(.horizontal, 16)

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -9,30 +9,45 @@
 import SwiftUI
 
 struct WatchAdButton: View {
-	let onReward: () -> Void
+	@EnvironmentObject private var adManager: SwiftUIAdManager
+	@Binding var isAdFree: Bool
+	var onAdFreeActivated: (() -> Void)?
+
 	@State private var showConfirmation = false
 
 	var body: some View {
-		Button(action: {
-			showConfirmation = true
-		}) {
-			Image(systemName: "gift")
-				.font(.system(size: 14, weight: .medium))
-				.frame(width: 50, height: 50)
-				.background(Color.appSecondaryButton)
-				.foregroundColor(.appAccent)
-				.cornerRadius(12)
-		}
-		.buttonStyle(.plain)
-		.confirmationDialog(
-			"Remove ads for 1 hour?",
-			isPresented: $showConfirmation,
-			titleVisibility: .visible
-		) {
-			Button("Watch Ad", action: onReward)
-			Button(role: .cancel) {} label: { Text("Cancel") }
-		} message: {
-			Text("Watch a short ad to enjoy 1 hour ad-free.")
+		if !isAdFree {
+			Button(action: {
+				showConfirmation = true
+			}) {
+				Image(systemName: "gift")
+					.font(.system(size: 14, weight: .medium))
+					.frame(width: 50, height: 50)
+					.background(Color.appSecondaryButton)
+					.foregroundColor(.appAccent)
+					.cornerRadius(12)
+			}
+			.buttonStyle(.plain)
+			.transition(.opacity.combined(with: .scale(scale: 0.8)))
+			.confirmationDialog(
+				"Remove ads for 1 hour?",
+				isPresented: $showConfirmation,
+				titleVisibility: .visible
+			) {
+				Button("Watch Ad") {
+					adManager.showRewarded { rewarded in
+						guard rewarded else { return }
+						LSDefaults.activateAdFree()
+						withAnimation(.easeInOut(duration: 0.25)) {
+							isAdFree = true
+						}
+						onAdFreeActivated?()
+					}
+				}
+				Button(role: .cancel) {} label: { Text("Cancel") }
+			} message: {
+				Text("Watch a short ad to enjoy 1 hour ad-free.")
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Moves the inline rewarded-ad gift button (with confirmation dialog) out of `TranslationScreen` into a new `Views/WatchAdButton.swift` component
- `TranslationScreen` now uses `WatchAdButton { ... }` — no behavior change
- Removes `@State private var showWatchAdConfirmation` from `TranslationScreen`

## Test plan
- [ ] Tap the gift button → confirmation dialog appears
- [ ] Tap "Watch Ad" → rewarded ad loads and plays
- [ ] After reward → banner and gift button disappear, toast shows "Ad-free for 1 hour"
- [ ] Tap "Cancel" → nothing happens

## Result
<img width="367" height="113" alt="스크린샷 2026-03-10 오후 9 01 42" src="https://github.com/user-attachments/assets/7f72b984-ac59-4b4f-a20b-a841b05339a9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)