### PR TITLE
feat: localize Watch Ad strings for all 13 locales

### DIFF
--- a/Projects/App/Resources/Strings/Base.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/Base.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Translate";
 "Please rate '%@' or recommend it to your friends."="Please rate '%@' or recommend it to your friends.";
 "Translated Language:"="Translated Language:";
 "Font Size"="Font Size";
+"Remove ads for 1 hour?"="Remove ads for 1 hour?";
+"Watch Ad"="Watch Ad";
+"Watch a short ad to enjoy 1 hour ad-free."="Watch a short ad to enjoy 1 hour ad-free.";
+"Ad-free for 1 hour"="Ad-free for 1 hour";
 

--- a/Projects/App/Resources/Strings/de.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/de.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Übersetzen";
 "Please rate '%@' or recommend it to your friends."="Bitte bewerten Sie '%@' oder empfehlen Sie es Ihren Freunden.";
 "Translated Language:"="Translated Language:";
 "Font Size"="Schriftgröße";
+"Remove ads for 1 hour?"="Werbung für 1 Stunde entfernen?";
+"Watch Ad"="Werbung ansehen";
+"Watch a short ad to enjoy 1 hour ad-free."="Schau dir eine kurze Werbung an und genieße 1 Stunde ohne Werbung.";
+"Ad-free for 1 hour"="1 Stunde werbefrei";
 

--- a/Projects/App/Resources/Strings/es.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/es.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Traducir";
 "Please rate '%@' or recommend it to your friends."="Califique '% @' o recomiéndelo a sus amigos.";
 "Translated Language:"="Lenguaje de traducción:";
 "Font Size"="Tamaño de fuente";
+"Remove ads for 1 hour?"="¿Eliminar anuncios por 1 hora?";
+"Watch Ad"="Ver anuncio";
+"Watch a short ad to enjoy 1 hour ad-free."="Mira un anuncio corto para disfrutar 1 hora sin anuncios.";
+"Ad-free for 1 hour"="Sin anuncios por 1 hora";
 

--- a/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Traduire";
 "Please rate '%@' or recommend it to your friends."="S'il vous plaît noter '%@' ou le recommander à vos amis.";
 "Translated Language:"="Langue de traduction:";
 "Font Size"="Taille de police";
+"Remove ads for 1 hour?"="Supprimer les publicités pendant 1 heure ?";
+"Watch Ad"="Voir la pub";
+"Watch a short ad to enjoy 1 hour ad-free."="Regardez une courte publicité pour profiter d'1 heure sans pub.";
+"Ad-free for 1 hour"="Sans pub pendant 1 heure";
 

--- a/Projects/App/Resources/Strings/id.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/id.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Menterjemahkan";
 "Please rate '%@' or recommend it to your friends."="Silakan beri nilai '%@' atau merekomendasikannya kepada teman-teman Anda.";
 "Translated Language:"="Bahasa terjemahan:";
 "Font Size"="Ukuran font";
+"Remove ads for 1 hour?"="Hapus iklan selama 1 jam?";
+"Watch Ad"="Tonton Iklan";
+"Watch a short ad to enjoy 1 hour ad-free."="Tonton iklan singkat untuk menikmati 1 jam tanpa iklan.";
+"Ad-free for 1 hour"="Bebas iklan 1 jam";
 

--- a/Projects/App/Resources/Strings/it.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/it.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Tradurre";
 "Please rate '%@' or recommend it to your friends."="Valuta '%@' o raccomandalo ai tuoi amici.";
 "Translated Language:"="Translated Language:";
 "Font Size"="Dimensione carattere";
+"Remove ads for 1 hour?"="Rimuovere le pubblicità per 1 ora?";
+"Watch Ad"="Guarda pubblicità";
+"Watch a short ad to enjoy 1 hour ad-free."="Guarda una breve pubblicità per goderti 1 ora senza pubblicità.";
+"Ad-free for 1 hour"="Senza pubblicità per 1 ora";
 

--- a/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
@@ -44,3 +44,7 @@ Translate="翻訳";
 "Please rate '%@' or recommend it to your friends."="'％@'を評価するか、お友達に推薦してください.";
 "Translated Language:"="翻訳された言語：";
 "Font Size"="フォントサイズ";
+"Remove ads for 1 hour?"="1時間広告を削除しますか？";
+"Watch Ad"="広告を見る";
+"Watch a short ad to enjoy 1 hour ad-free."="短い広告を見て、1時間広告なしでお楽しみください。";
+"Ad-free for 1 hour"="1時間広告なし";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -45,3 +45,7 @@ Translate="번역";
 "Native Language:"="원문 언어:";
 "Translated Language:"="번역 언어:";
 "Font Size"="글자 크기";
+"Remove ads for 1 hour?"="1시간 동안 광고를 제거할까요?";
+"Watch Ad"="광고 보기";
+"Watch a short ad to enjoy 1 hour ad-free."="짧은 광고를 시청하고 1시간 동안 광고 없이 이용하세요.";
+"Ad-free for 1 hour"="1시간 광고 없음";

--- a/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Переведите";
 "Please rate '%@' or recommend it to your friends."="Пожалуйста, оцените '% @' или порекомендуйте его своим друзьям.";
 "Translated Language:"="Translated Language:";
 "Font Size"="Размер шрифта";
+"Remove ads for 1 hour?"="Убрать рекламу на 1 час?";
+"Watch Ad"="Смотреть рекламу";
+"Watch a short ad to enjoy 1 hour ad-free."="Посмотрите короткую рекламу и пользуйтесь приложением без рекламы 1 час.";
+"Ad-free for 1 hour"="Без рекламы 1 час";
 

--- a/Projects/App/Resources/Strings/th.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/th.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="แปลความ";
 "Please rate '%@' or recommend it to your friends."="โปรดให้คะแนน '%@' หรือแนะนำให้เพื่อนของคุณ";
 "Translated Language:"="ภาษาการแปล:";
 "Font Size"="ขนาดตัวอักษร";
+"Remove ads for 1 hour?"="ลบโฆษณาเป็นเวลา 1 ชั่วโมง?";
+"Watch Ad"="ดูโฆษณา";
+"Watch a short ad to enjoy 1 hour ad-free."="ดูโฆษณาสั้นๆ เพื่อใช้งานโดยไม่มีโฆษณา 1 ชั่วโมง";
+"Ad-free for 1 hour"="ไม่มีโฆษณา 1 ชั่วโมง";
 

--- a/Projects/App/Resources/Strings/vi.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/vi.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="Dịch";
 "Please rate '%@' or recommend it to your friends."="Hãy đánh giá '%@' hoặc giới thiệu nó cho bạn bè của bạn.";
 "Translated Language:"="Ngôn ngữ dịch:";
 "Font Size"="Cỡ chữ";
+"Remove ads for 1 hour?"="Xóa quảng cáo trong 1 giờ?";
+"Watch Ad"="Xem quảng cáo";
+"Watch a short ad to enjoy 1 hour ad-free."="Xem một quảng cáo ngắn để trải nghiệm 1 giờ không có quảng cáo.";
+"Ad-free for 1 hour"="Không quảng cáo 1 giờ";
 

--- a/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="翻译";
 "Please rate '%@' or recommend it to your friends."="请评价'%@'或推荐给你的朋友";
 "Translated Language:"="翻译语言：";
 "Font Size"="字体大小";
+"Remove ads for 1 hour?"="移除1小时广告？";
+"Watch Ad"="观看广告";
+"Watch a short ad to enjoy 1 hour ad-free."="观看短广告，享受1小时无广告体验。";
+"Ad-free for 1 hour"="1小时无广告";
 

--- a/Projects/App/Resources/Strings/zh-Hant-TW.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hant-TW.lproj/Localizable.strings
@@ -44,4 +44,8 @@ Translate="翻譯";
 "Please rate '%@' or recommend it to your friends."="請評價'%@'或推薦給你的朋友";
 "Translated Language:"="翻譯語言：";
 "Font Size"="字體大小";
+"Remove ads for 1 hour?"="移除1小時廣告？";
+"Watch Ad"="觀看廣告";
+"Watch a short ad to enjoy 1 hour ad-free."="觀看短廣告，享受1小時無廣告體驗。";
+"Ad-free for 1 hour"="1小時無廣告";
 


### PR DESCRIPTION
## Summary
- Adds 4 new localized strings introduced by the rewarded ad feature across all 13 supported locales (Base, ko, ja, zh-Hans, zh-Hant-TW, es, de, fr, ru, it, id, th, vi)
- No Swift code changes needed — SwiftUI `Text` and `Button` use `LocalizedStringKey` automatically

## New strings
| Key | Example (ko) |
|-----|------|
| `"Remove ads for 1 hour?"` | 1시간 동안 광고를 제거할까요? |
| `"Watch Ad"` | 광고 보기 |
| `"Watch a short ad to enjoy 1 hour ad-free."` | 짧은 광고를 시청하고 1시간 동안 광고 없이 이용하세요. |
| `"Ad-free for 1 hour"` | 1시간 광고 없음 |

## Test plan
- [ ] Switch device language to each supported locale
- [ ] Tap gift button → confirmation dialog shows in correct language
- [ ] After reward → toast shows in correct language

## Result
<img width="364" height="201" alt="스크린샷 2026-03-11 오전 9 39 50" src="https://github.com/user-attachments/assets/e5a2b726-5239-4f21-9257-7735f67f620b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)