### PR TITLE
fix: move all AnalyticsManager members inside class body

### DIFF
--- a/Projects/App/Sources/Managers/AnalyticsManager.swift
+++ b/Projects/App/Sources/Managers/AnalyticsManager.swift
@@ -12,11 +12,6 @@ import Firebase
 // MARK: - AnalyticsManager
 
 final class AnalyticsManager: ObservableObject {
-}
-
-	// MARK: - Init
-
-	init() {}
 
 	// MARK: - Event Names
 


### PR DESCRIPTION
Fixes broken class structure where closing brace was placed immediately after the class declaration, leaving all enums and methods outside the type. Build verified before this commit.