### PR TITLE
fix: raise translation input limit from 100 to 500 characters

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -99,7 +99,7 @@ struct TranslationScreen: View {
 						onSwap: {
 							viewModel.swapLanguages()
 						},
-						maxLength: 100
+						maxLength: 500
 					)
 					.padding(.horizontal, 16)
 

--- a/Projects/App/Sources/Views/TranslationInputView.swift
+++ b/Projects/App/Sources/Views/TranslationInputView.swift
@@ -101,7 +101,7 @@ struct TranslationInputView: View {
 		placeholder: "Please input your message to be translated as Korean",
         onLocaleChange: { _ in },
         onSwap: {  },
-		maxLength: 100
+		maxLength: 500
 	)
     .frame(height: 100)
     .padding()


### PR DESCRIPTION
## Summary
- Raises `maxLength` from 100 → 500 in `TranslationInputView` and `TranslationScreen`
- Naver Papago supports up to 5,000 chars; 500 is a practical mobile limit

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)