### PR TITLE
fix: show time instead of relative duration in HistoryRow

### DIFF
--- a/Projects/App/Sources/Views/HistoryRow.swift
+++ b/Projects/App/Sources/Views/HistoryRow.swift
@@ -61,7 +61,7 @@ struct HistoryRow: View {
 				}
 
 				// Relative timestamp
-				Text(entry.timestamp, style: .relative)
+				Text(entry.timestamp, style: .time)
 					.font(.caption2)
 					.foregroundColor(.appTextPlaceholder)
 					.multilineTextAlignment(.trailing)


### PR DESCRIPTION
## Summary

- Replace `style: .relative` with `style: .time` in `HistoryRow` timestamp

Section headers already show the date — the row only needs to answer "what time". Relative strings like "2일 20시간" are redundant and have no "ago" suffix, making them confusing. Time-only (e.g. `오후 3:42`) is clean, always accurate, and matches the iOS Mail/Messages pattern.

## Test Plan

- [ ] Open History — each row shows a time (e.g. `오후 3:42`) instead of a relative duration
- [ ] Section headers still show the date

## Result
<img width="364" height="142" alt="스크린샷 2026-03-29 오전 11 00 42" src="https://github.com/user-attachments/assets/16dc3709-7998-48b9-a810-10df6dd94de1" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)