### PR TITLE
fix: restore output text when re-translating from history

### DIFF
--- a/Projects/App/Sources/Screens/HistoryScreen.swift
+++ b/Projects/App/Sources/Screens/HistoryScreen.swift
@@ -13,7 +13,7 @@ import SwiftData
 
 struct HistoryScreen: View {
 	/// Called when user taps Re-translate on a detail sheet.
-	let onRetranslate: (String, String, String) -> Void
+	let onRetranslate: (String, String, String, String) -> Void
 
 	@Environment(\.dismiss) private var dismiss
 	@Environment(\.modelContext) private var modelContext
@@ -57,9 +57,9 @@ struct HistoryScreen: View {
 				}
 			}
 			.sheet(item: $selectedEntry) { entry in
-				HistoryDetailSheet(entry: entry) { sourceText, sourceLang, targetLang in
+				HistoryDetailSheet(entry: entry) { sourceText, translatedText, sourceLang, targetLang in
 					dismiss()
-					onRetranslate(sourceText, sourceLang, targetLang)
+					onRetranslate(sourceText, translatedText, sourceLang, targetLang)
 				}
 				.presentationDetents([.large])
 				.presentationDragIndicator(.visible)

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -211,8 +211,8 @@ struct TranslationScreen: View {
 			)
 		}
 		.sheet(isPresented: $showHistory) {
-			HistoryScreen { sourceText, sourceLang, targetLang in
-				applyRetranslate(sourceText: sourceText, sourceLang: sourceLang, targetLang: targetLang)
+			HistoryScreen { sourceText, translatedText, sourceLang, targetLang in
+				applyRetranslate(sourceText: sourceText, translatedText: translatedText, sourceLang: sourceLang, targetLang: targetLang)
 			}
 		}
 	}
@@ -229,7 +229,7 @@ struct TranslationScreen: View {
 		modelContext.insert(entry)
 	}
 
-	private func applyRetranslate(sourceText: String, sourceLang: String, targetLang: String) {
+	private func applyRetranslate(sourceText: String, translatedText: String, sourceLang: String, targetLang: String) {
 		if let source = TranslationLocale(rawValue: sourceLang) {
 			viewModel.updateNativeLocale(source)
 		}
@@ -237,7 +237,7 @@ struct TranslationScreen: View {
 			viewModel.updateTranslatedLocale(target)
 		}
 		viewModel.nativeText = sourceText
-		viewModel.translatedText = ""
+		viewModel.translatedText = translatedText
 	}
 }
 

--- a/Projects/App/Sources/Views/HistoryDetailSheet.swift
+++ b/Projects/App/Sources/Views/HistoryDetailSheet.swift
@@ -11,8 +11,8 @@ import SwiftData
 
 struct HistoryDetailSheet: View {
 	let entry: TranslationEntry
-	/// Called when the user taps Re-translate.  Arguments: (sourceText, sourceLang, targetLang)
-	let onRetranslate: (String, String, String) -> Void
+	/// Called when the user taps Re-translate.  Arguments: (sourceText, translatedText, sourceLang, targetLang)
+	let onRetranslate: (String, String, String, String) -> Void
 
 	@Environment(\.dismiss) private var dismiss
 	@State private var isRotated: Bool = false
@@ -103,7 +103,7 @@ struct HistoryDetailSheet: View {
 						// Re-translate
 						Button(action: {
 							dismiss()
-							onRetranslate(entry.sourceText, entry.sourceLang, entry.targetLang)
+							onRetranslate(entry.sourceText, entry.translatedText, entry.sourceLang, entry.targetLang)
 						}) {
 							Label("Re-translate".localized(), systemImage: "arrow.clockwise")
 								.font(.system(size: 15, weight: .semibold))


### PR DESCRIPTION
## Summary

- Re-translate from history now fills both input and output from the saved entry — no need to tap Translate again
- The user already saw the translation in history; re-calling the API was unnecessary

## Root Cause

applyRetranslate was setting translatedText to empty, clearing the output. It now sets it directly from the history entry.

## Test Plan

- [ ] Open History, tap an entry, tap Re-translate
- [ ] TranslationScreen shows both input and output pre-filled immediately
- [ ] No need to press Translate again

Generated with Claude Code