### PR TITLE
fix: history UX polish — label, share button, empty state

### DIFF
--- a/Projects/App/Resources/Strings/Base.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/Base.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Translate";
 "Favorited"="Favorited";
 "No translations yet"="No translations yet";
 "Re-translate"="Re-translate";
+"Translate Again"="Translate Again";
+"No favorites yet"="No favorites yet";
 "Detail"="Detail";
 "Filter"="Filter";

--- a/Projects/App/Resources/Strings/de.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/de.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Übersetzen";
 "Favorited"="Favoriten";
 "No translations yet"="Noch keine Übersetzungen";
 "Re-translate"="Neu übersetzen";
+"Translate Again"="Übersetzen";
+"No favorites yet"="Keine Favoriten";
 "Detail"="Detail";
 "Filter"="Filter";

--- a/Projects/App/Resources/Strings/es.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/es.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Traducir";
 "Favorited"="Favoritos";
 "No translations yet"="Sin traducciones aún";
 "Re-translate"="Volver a traducir";
+"Translate Again"="Traducir";
+"No favorites yet"="Sin favoritos";
 "Detail"="Detalle";
 "Filter"="Filtro";

--- a/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Traduire";
 "Favorited"="Favoris";
 "No translations yet"="Pas encore de traductions";
 "Re-translate"="Retraduire";
+"Translate Again"="Traduire";
+"No favorites yet"="Aucun favori";
 "Detail"="Détail";
 "Filter"="Filtre";

--- a/Projects/App/Resources/Strings/id.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/id.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Menterjemahkan";
 "Favorited"="Favorit";
 "No translations yet"="Belum ada terjemahan";
 "Re-translate"="Terjemahkan ulang";
+"Translate Again"="Terjemahkan";
+"No favorites yet"="Belum ada favorit";
 "Detail"="Detail";
 "Filter"="Filter";

--- a/Projects/App/Resources/Strings/it.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/it.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Tradurre";
 "Favorited"="Preferiti";
 "No translations yet"="Nessuna traduzione";
 "Re-translate"="Ritradurre";
+"Translate Again"="Traduci";
+"No favorites yet"="Nessun preferito";
 "Detail"="Dettaglio";
 "Filter"="Filtro";

--- a/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="翻訳";
 "Favorited"="お気に入り";
 "No translations yet"="翻訳履歴がありません";
 "Re-translate"="再翻訳";
+"Translate Again"="翻訳する";
+"No favorites yet"="お気に入りがありません";
 "Detail"="詳細";
 "Filter"="フィルター";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -56,5 +56,7 @@ Translate="번역";
 "Favorited"="즐겨찾기";
 "No translations yet"="번역 기록이 없습니다";
 "Re-translate"="다시 번역";
+"Translate Again"="번역하기";
+"No favorites yet"="즐겨찾기가 없습니다";
 "Detail"="상세";
 "Filter"="필터";

--- a/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="Переведите";
 "Favorited"="Избранное";
 "No translations yet"="Нет переводов";
 "Re-translate"="Перевести снова";
+"Translate Again"="Перевести";
+"No favorites yet"="Нет избранного";
 "Detail"="Подробности";
 "Filter"="Фильтр";

--- a/Projects/App/Resources/Strings/th.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/th.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="แปลความ";
 "Favorited"="รายการโปรด";
 "No translations yet"="ยังไม่มีการแปล";
 "Re-translate"="แปลอีกครั้ง";
+"Translate Again"="แปลเลย";
+"No favorites yet"="ยังไม่มีรายการโปรด";
 "Detail"="รายละเอียด";
 "Filter"="กรอง";

--- a/Projects/App/Resources/Strings/vi.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/vi.lproj/Localizable.strings
@@ -55,6 +55,8 @@ Translate="Dịch";
 "Favorited"="Yêu thích";
 "No translations yet"="Chưa có bản dịch";
 "Re-translate"="Dịch lại";
+"Translate Again"="Dịch ngay";
+"No favorites yet"="Chưa có mục yêu thích";
 "Detail"="Chi tiết";
 "Filter"="Lọc";
 

--- a/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="翻译";
 "Favorited"="收藏";
 "No translations yet"="暂无翻译记录";
 "Re-translate"="重新翻译";
+"Translate Again"="立即翻译";
+"No favorites yet"="暂无收藏";
 "Detail"="详情";
 "Filter"="筛选";

--- a/Projects/App/Resources/Strings/zh-Hant-TW.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hant-TW.lproj/Localizable.strings
@@ -55,5 +55,7 @@ Translate="翻譯";
 "Favorited"="收藏";
 "No translations yet"="尚無翻譯記錄";
 "Re-translate"="重新翻譯";
+"Translate Again"="立即翻譯";
+"No favorites yet"="尚無收藏";
 "Detail"="詳情";
 "Filter"="篩選";

--- a/Projects/App/Sources/Screens/HistoryScreen.swift
+++ b/Projects/App/Sources/Screens/HistoryScreen.swift
@@ -36,12 +36,14 @@ struct HistoryScreen: View {
 				if filterMode == .favorited {
 					HistoryListView(
 						predicate: #Predicate<TranslationEntry> { $0.isFavorited == true },
+						emptyTitle: "No favorites yet".localized(),
 						onFavoriteToggle: toggleFavorite,
 						onSelect: { selectedEntry = $0 }
 					)
 				} else {
 					HistoryListView(
 						predicate: nil,
+						emptyTitle: "No translations yet".localized(),
 						onFavoriteToggle: toggleFavorite,
 						onSelect: { selectedEntry = $0 }
 					)
@@ -84,6 +86,7 @@ private enum HistoryFilter: Hashable {
 private struct HistoryListView: View {
 	@Query private var entries: [TranslationEntry]
 
+	private let emptyTitle: String
 	private let onFavoriteToggle: (TranslationEntry) -> Void
 	private let onSelect: (TranslationEntry) -> Void
 
@@ -91,6 +94,7 @@ private struct HistoryListView: View {
 
 	init(
 		predicate: Predicate<TranslationEntry>?,
+		emptyTitle: String,
 		onFavoriteToggle: @escaping (TranslationEntry) -> Void,
 		onSelect: @escaping (TranslationEntry) -> Void
 	) {
@@ -99,6 +103,7 @@ private struct HistoryListView: View {
 			sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
 		)
 		_entries = Query(descriptor)
+		self.emptyTitle = emptyTitle
 		self.onFavoriteToggle = onFavoriteToggle
 		self.onSelect = onSelect
 	}
@@ -106,7 +111,7 @@ private struct HistoryListView: View {
 	var body: some View {
 		if entries.isEmpty {
 			ContentUnavailableView(
-				"No translations yet".localized(),
+				emptyTitle,
 				systemImage: "clock.arrow.circlepath"
 			)
 			.frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Projects/App/Sources/Views/HistoryDetailSheet.swift
+++ b/Projects/App/Sources/Views/HistoryDetailSheet.swift
@@ -105,7 +105,7 @@ struct HistoryDetailSheet: View {
 							dismiss()
 							onRetranslate(entry.sourceText, entry.translatedText, entry.sourceLang, entry.targetLang)
 						}) {
-							Label("Re-translate".localized(), systemImage: "arrow.clockwise")
+							Label("Translate Again".localized(), systemImage: "arrow.clockwise")
 								.font(.system(size: 15, weight: .semibold))
 								.frame(maxWidth: .infinity)
 								.frame(height: 48)

--- a/Projects/App/Sources/Views/HistoryRow.swift
+++ b/Projects/App/Sources/Views/HistoryRow.swift
@@ -66,24 +66,13 @@ struct HistoryRow: View {
 					.foregroundColor(.appTextPlaceholder)
 					.multilineTextAlignment(.trailing)
 
-				// Action row
-				HStack(spacing: 12) {
-					// Favorite toggle
-					Button(action: onFavoriteToggle) {
-						Image(systemName: entry.isFavorited ? "star.fill" : "star")
-							.font(.system(size: 14, weight: .medium))
-							.foregroundColor(entry.isFavorited ? .yellow : .appTextPlaceholder)
-					}
-					.buttonStyle(.plain)
-
-					// Share
-					ShareLink(item: entry.translatedText) {
-						Image(systemName: "square.and.arrow.up")
-							.font(.system(size: 14, weight: .medium))
-							.foregroundColor(.appTextPlaceholder)
-					}
-					.buttonStyle(.plain)
+				// Favorite toggle
+				Button(action: onFavoriteToggle) {
+					Image(systemName: entry.isFavorited ? "star.fill" : "star")
+						.font(.system(size: 14, weight: .medium))
+						.foregroundColor(entry.isFavorited ? .yellow : .appTextPlaceholder)
 				}
+				.buttonStyle(.plain)
 			}
 		}
 		.padding(.vertical, 4)


### PR DESCRIPTION
## Summary

- **Rename** "Re-translate" → "Translate Again" — clearer intent, communicates the action without implying it dismisses
- **Remove** share button from `HistoryRow` — reduces accidental taps, share is already in `HistoryDetailSheet`
- **Fix** empty state on Favorited tab — shows "No favorites yet" instead of the generic "No translations yet"
- All changes localized across 13 locales

## Test Plan

- [ ] Open History detail sheet — button reads "Translate Again"
- [ ] HistoryRow trailing area shows only: flag pair + time + star
- [ ] Switch to Favorited tab with no favorites — shows "No favorites yet"
- [ ] All tab empty state still shows "No translations yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)