### PR TITLE
fix: preserve Chinese locale scripts

### DIFF
--- a/Projects/App/Sources/Managers/TranslationManager.swift
+++ b/Projects/App/Sources/Managers/TranslationManager.swift
@@ -31,11 +31,11 @@ class TranslationManager {
      - returns: the indication to able to translate by given locale of source/target
      */
     public func canSupportTranslate(source : Locale, target : Locale) -> Bool{
-        guard let sourceTransLocale = TranslationLocale(rawValue: source.language.languageCode?.identifier ?? "") else{
+        guard let sourceTransLocale = TranslationLocale.from(locale: source) else{
             return false;
         }
         
-        guard let targetTransLocale = TranslationLocale(rawValue: target.language.languageCode?.identifier  ?? "") else{
+        guard let targetTransLocale = TranslationLocale.from(locale: target) else{
             return false;
         }
         
@@ -52,8 +52,7 @@ class TranslationManager {
      - returns: target locales can be translated from given source locale
      */
     public func supportedTargetLangs(source: Locale) -> [TranslationLocale]{
-        let sourceLangCode = source.language.languageCode?.identifier ?? "";
-        guard let sourceLang = TranslationLocale(rawValue: sourceLangCode) else{
+        guard let sourceLang = TranslationLocale.from(locale: source) else{
             return [];
         }
         

--- a/Projects/App/Sources/Models/TranslationLocale+Extension.swift
+++ b/Projects/App/Sources/Models/TranslationLocale+Extension.swift
@@ -50,8 +50,26 @@ extension TranslationLocale {
 	}
 	
 	static func from(locale: Locale) -> TranslationLocale? {
-		let identifier = locale.language.languageCode?.identifier ?? ""
-		return TranslationLocale(rawValue: identifier)
+		let languageCode = locale.language.languageCode?.identifier.lowercased() ?? ""
+		let scriptCode = locale.language.script?.identifier.lowercased()
+		
+		switch languageCode {
+		case "zh":
+			if scriptCode == "hant" {
+				return .taiwan
+			}
+			if scriptCode == "hans" {
+				return .chinese
+			}
+			
+			let normalizedIdentifier = locale.identifier.lowercased().replacingOccurrences(of: "_", with: "-")
+			if normalizedIdentifier.contains("hant") || normalizedIdentifier.contains("zh-tw") {
+				return .taiwan
+			}
+			return .chinese
+		default:
+			return TranslationLocale(rawValue: languageCode)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix locale mapping so Chinese script variants are preserved instead of collapsing to plain `zh` during translation support checks.
- Restore Korean → Chinese and Korean → Traditional Chinese support by routing locale matching through `TranslationLocale.from(locale:)`.

## Test Status
- Environment review confirmed the root cause and patch path.
- Full `mise x -- tuist ...` verification is blocked here by missing `tuist auth login`.

## Flow
```mermaid
flowchart TD
    A[User selects Korean source] --> B[User selects Chinese target]
    B --> C[Locale mapping keeps Hans/Hant script]
    C --> D[Supported pair resolves correctly]
    D --> E[Translation can proceed]
```