### PR TITLE
chore: pin Tuist 4.200.5

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -143,8 +143,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/2sem/LSExtensions",
       "state" : {
-        "revision" : "76152a1fa0d0f5cb4726bdb5b1934567bad26fff",
-        "version" : "0.1.22"
+        "revision" : "aa7f790c6e65a45dcbacd11c00be1991144f4e2a",
+        "version" : "0.1.23"
       }
     },
     {

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-tuist = "latest"
+tuist = "4.200.5"


### PR DESCRIPTION
## Summary

- Pins Tuist to `4.200.5` in `mise.toml` instead of using `latest`.
- Regenerated the project successfully with Tuist `4.200.5`.
- Keeps the resolved dependency update for `LSExtensions` from `0.1.22` to `0.1.23`.

## What changed in Tuist since the previous local version

Previous local Tuist baseline found: `4.183.0`  
New version: `4.200.5`

Notable Tuist changes included in this upgrade:

- Improved SwiftPM support:
  - Better `Package.resolved` stability.
  - SwiftPM workspace-state paths are now anchored to scratch directories.
  - Added support for SwiftPM prebuilt libraries.
  - Improved handling of SwiftPM registry transformation via SwifterPM.
- Xcode/project generation fixes:
  - Fixes for module map paths, including paths with whitespace.
  - Better handling of buildable folders, xcstrings, asset symbol generation, and generated bundle accessors.
  - Fixes around static frameworks, xcframework search paths, and embedded products.
- Build/test improvements:
  - Better XCTest and Swift Testing support framework caching.
  - Improved test sharding stability and error reporting.
  - Added support for generated `.xctestplan` files.
  - Added `--inspect-mode off` to skip result bundle upload.
- Caching and performance:
  - Improved cache hash stability.
  - Reduced subprocess overhead for large SwiftPM graphs.
  - Added local Xcode module cache breakdown reporting.
- CLI/platform fixes:
  - Fixes for Xcode 26/27 compatibility cases.
  - More resilient command tracking, logging, and metadata upload behavior.
  - `tuist build` now warns that it is deprecated in favor of `tuist xcodebuild`.

Release reference: https://github.com/tuist/tuist/releases/tag/4.200.5

## Verification

- [x] `mise x -- tuist version` returns `4.200.5`
- [x] `mise x -- tuist generate`
- [x] `mise x -- tuist build`

## Notes

`tuist build` completed successfully, but Tuist now warns that it is deprecated in favor of `tuist xcodebuild`.