### PR TITLE
chore: upgrade CI Xcode to 26.5

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Select Xcode
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
 
     - name: Install Mise
       uses: jdx/mise-action@v2

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Import Secret Key
         run: |


### PR DESCRIPTION
## Summary
- Update CI Xcode selection from 26.1.1 to 26.5
- Apply the change to build/test and deploy workflows

## Verification
- Not run locally; GitHub Actions runner image availability will be verified by CI.

## Flow
```mermaid
flowchart TD
  Push[Push / PR] --> BuildTest[Build & Test workflow]
  ManualDeploy[Manual deploy] --> Deploy[Deploy iOS workflow]
  BuildTest --> Xcode26_5[Select Xcode 26.5]
  Deploy --> Xcode26_5
```