### PR TITLE
feat: apply Duo translation redesign

### DIFF
--- a/Projects/App/Sources/Extensions/Color+App.swift
+++ b/Projects/App/Sources/Extensions/Color+App.swift
@@ -7,8 +7,76 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension Color {
+	// MARK: - Duo Design Tokens
+
+	/// Duo source-speaker accent: "you".
+	static var duoYouAccent: Color {
+		Color.dynamic(light: 0xE58A00, dark: 0xFFB443)
+	}
+
+	/// Duo source-speaker deeper accent for labels and gradients.
+	static var duoYouAccentDeep: Color {
+		Color.dynamic(light: 0xC67600, dark: 0xFF7A59)
+	}
+
+	/// Duo translated-reader accent: "them".
+	static var duoThemAccent: Color {
+		Color.dynamic(light: 0x0FB5A0, dark: 0x34E0C4)
+	}
+
+	/// Duo translated-reader deeper accent for labels and gradients.
+	static var duoThemAccentDeep: Color {
+		Color.dynamic(light: 0x0C9585, dark: 0x22B8A6)
+	}
+
+	static var duoBackground: Color {
+		Color.dynamic(light: 0xEEF1F5, dark: 0x0C0E14)
+	}
+
+	static var duoSurface: Color {
+		Color.dynamic(light: 0xFFFFFF, dark: 0x12151D)
+	}
+
+	static var duoElevatedSurface: Color {
+		Color.dynamic(light: 0xFFFFFF, dark: 0x161A24)
+	}
+
+	static var duoControlSurface: Color {
+		Color.dynamic(light: 0xE2E6EC, dark: 0x242A36)
+	}
+
+	static var duoTextPrimary: Color {
+		Color.dynamic(light: 0x131720, dark: 0xF2F4F8)
+	}
+
+	static var duoTextSecondary: Color {
+		Color.dynamic(light: 0x3E4453, dark: 0xC5CAD6)
+	}
+
+	static var duoTextMuted: Color {
+		Color.dynamic(light: 0xA3AAB6, dark: 0x5A6072)
+	}
+
+	static var duoDivider: Color {
+		Color.dynamic(light: 0xD2D8E0, dark: 0x2A303C)
+	}
+
+	private static func dynamic(light: UInt, dark: UInt) -> Color {
+		Color(uiColor: UIColor { traitCollection in
+			uiColor(hex: traitCollection.userInterfaceStyle == .dark ? dark : light)
+		})
+	}
+
+	private static func uiColor(hex: UInt) -> UIColor {
+		let red = CGFloat((hex >> 16) & 0xFF) / 255
+		let green = CGFloat((hex >> 8) & 0xFF) / 255
+		let blue = CGFloat(hex & 0xFF) / 255
+		return UIColor(red: red, green: green, blue: blue, alpha: 1)
+	}
+
 	// MARK: - Background Colors
 	
 	/// 배경 그라데이션 시작 색상
@@ -77,4 +145,3 @@ extension Color {
 		Color("SecondaryButton")
 	}
 }
-

--- a/Projects/App/Sources/Extensions/GoogleAds/BannerAdSwiftUIView.swift
+++ b/Projects/App/Sources/Extensions/GoogleAds/BannerAdSwiftUIView.swift
@@ -11,6 +11,11 @@ import GoogleMobileAds
 struct BannerAdSwiftUIView: View {
 	@EnvironmentObject private var adManager: SwiftUIAdManager
 	@State private var coordinator = BannerAdCoordinator()
+	let adWidth: CGFloat?
+
+	init(adWidth: CGFloat? = nil) {
+		self.adWidth = adWidth
+	}
 
 	var body: some View {
 		Group {
@@ -25,14 +30,19 @@ struct BannerAdSwiftUIView: View {
 		.onChange(of: adManager.isReady, initial: true) { _, isReady in
 			guard isReady else { return }
 			guard !adManager.isAdFree else { return }
-			coordinator.load(withAdManager: adManager)
+			coordinator.load(withAdManager: adManager, adWidth: adWidth)
 		}
 		.onChange(of: adManager.isAdFree, initial: true) { _, isAdFree in
 			if isAdFree {
 				coordinator.reset()
 			} else if adManager.isReady {
-				coordinator.load(withAdManager: adManager)
+				coordinator.load(withAdManager: adManager, adWidth: adWidth)
 			}
+		}
+		.onChange(of: adWidth) { _, newValue in
+			guard adManager.isReady else { return }
+			guard !adManager.isAdFree else { return }
+			coordinator.load(withAdManager: adManager, adWidth: newValue)
 		}
 	}
 }
@@ -41,13 +51,23 @@ struct BannerAdSwiftUIView: View {
 final class BannerAdCoordinator {
 	var bannerView: BannerView?
 	private var hasLoaded = false
+	private var loadedWidth: CGFloat?
 
-	func load(withAdManager manager: SwiftUIAdManager) {
-		guard !hasLoaded else { return }
+	func load(withAdManager manager: SwiftUIAdManager, adWidth: CGFloat? = nil) {
+		let roundedWidth = adWidth.map { floor($0) }
+		guard !hasLoaded || loadedWidth != roundedWidth else { return }
 
-		if let banner = manager.createBannerAdView(withAdSize: AdSizeBanner, forUnit: .banner) {
+		let size: AdSize
+		if let roundedWidth, roundedWidth > 0 {
+			size = currentOrientationAnchoredAdaptiveBanner(width: roundedWidth)
+		} else {
+			size = AdSizeBanner
+		}
+
+		if let banner = manager.createBannerAdView(withAdSize: size, forUnit: .banner) {
 			self.bannerView = banner
 			self.hasLoaded = true
+			self.loadedWidth = roundedWidth
 			let request = Request()
 			banner.load(request)
 		}
@@ -56,6 +76,7 @@ final class BannerAdCoordinator {
 	func reset() {
 		bannerView = nil
 		hasLoaded = false
+		loadedWidth = nil
 	}
 }
 

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -22,8 +22,6 @@ struct TranslationScreen: View {
 	@State private var lastHandledTranslationID: UUID?
 	@FocusState private var isInputFocused: Bool
 
-	private let outputCardHeight: CGFloat = 248
-	private let inputCardHeight: CGFloat = 300
 	private let topContentPadding: CGFloat = 12
 
 	init() {
@@ -105,7 +103,8 @@ struct TranslationScreen: View {
 							},
 							deviceOrientation: viewModel.deviceOrientation
 						)
-						.frame(height: outputCardHeight)
+						.frame(maxHeight: .infinity)
+						.layoutPriority(1)
 						.padding(.horizontal, 16)
 					}
 
@@ -136,7 +135,8 @@ struct TranslationScreen: View {
 						},
 						maxLength: 500
 					)
-					.frame(height: inputCardHeight)
+					.frame(maxHeight: .infinity)
+					.layoutPriority(1)
 					.padding(.horizontal, 16)
 
 					// Action Buttons
@@ -201,7 +201,6 @@ struct TranslationScreen: View {
 							.padding(.horizontal, 16)
 					}
 
-					Spacer(minLength: 0)
 				}
 				.safeAreaPadding(.bottom, 12)
 				.onTapGesture {

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -22,6 +22,10 @@ struct TranslationScreen: View {
 	@State private var lastHandledTranslationID: UUID?
 	@FocusState private var isInputFocused: Bool
 
+	private let outputCardHeight: CGFloat = 248
+	private let inputCardHeight: CGFloat = 300
+	private let topContentPadding: CGFloat = 12
+
 	init() {
 		// TranslationSession will be created dynamically in TranslationViewModel
 		// when translate button is pressed
@@ -32,12 +36,12 @@ struct TranslationScreen: View {
 		let sessionBindingRequestID = viewModel.sessionBindingRequestID
 
 		ZStack {
-			// Gradient Background
 			LinearGradient(
 				colors: [
-					.appBackgroundGradientStart,
-					.appBackgroundGradientMid,
-					.appBackgroundGradientEnd
+					.duoBackground,
+					.duoBackground,
+					.duoThemAccent.opacity(0.08),
+					.duoYouAccent.opacity(0.06)
 				],
 				startPoint: .topLeading,
 				endPoint: .bottomTrailing
@@ -70,7 +74,21 @@ struct TranslationScreen: View {
 				}.transition(.scale)
 			} else {
 				// Normal Mode - Show all UI elements
-				VStack(spacing: 20) {
+				VStack(spacing: 8) {
+					DuoHeaderView(
+						onHistoryTapped: { showHistory = true },
+						onSettingsTapped: { }
+					)
+						.padding(.horizontal, 18)
+						.padding(.top, topContentPadding)
+
+					DuoModeSelectorView(
+						isSpeechSelected: showSpeechRecognition,
+						onTypeTapped: { showSpeechRecognition = false },
+						onSpeakTapped: { showSpeechRecognition = true }
+					)
+						.padding(.horizontal, 16)
+
 					// Translated Output Section
 					if !showSpeechRecognition && !isInputFocused {
 						TranslationOutputView(
@@ -87,13 +105,17 @@ struct TranslationScreen: View {
 							},
 							deviceOrientation: viewModel.deviceOrientation
 						)
+						.frame(height: outputCardHeight)
 						.padding(.horizontal, 16)
-						.padding(.top, 20)
 					}
 
 					if !SwiftUIAdManager.isDisabled, !adManager.isAdFree {
-						BannerAdSwiftUIView()
-							.frame(height: 50)
+						GeometryReader { proxy in
+							BannerAdSwiftUIView(adWidth: proxy.size.width)
+								.frame(maxWidth: .infinity, minHeight: 50, maxHeight: 50)
+						}
+						.frame(height: 50)
+						.padding(.horizontal, 16)
 					}
 
 					// Native Input Section
@@ -114,6 +136,7 @@ struct TranslationScreen: View {
 						},
 						maxLength: 500
 					)
+					.frame(height: inputCardHeight)
 					.padding(.horizontal, 16)
 
 					// Action Buttons
@@ -134,43 +157,38 @@ struct TranslationScreen: View {
 								}
 							}
 							.frame(maxWidth: .infinity)
-							.frame(height: 50)
+							.frame(height: 52)
 							.background(
 								LinearGradient(
 									colors: [
-										.appAccentGradientStart,
-										.appAccentGradientEnd
+										.duoThemAccent,
+										.duoThemAccentDeep
 									],
 									startPoint: .leading,
 									endPoint: .trailing
 								)
 							)
-							.foregroundColor(.white)
-							.cornerRadius(12)
+							.foregroundStyle(.white)
+							.clipShape(.rect(cornerRadius: 16, style: .continuous))
 						}
 						.disabled(!viewModel.canTranslate)
 
-						// Speech Recognition Button
 						Button(action: {
-							showSpeechRecognition = true
+							viewModel.toggleFullScreen()
 						}) {
-							Image(systemName: "mic")
-								.font(.system(size: 14, weight: .medium))
-								.frame(width: 50, height: 50)
-								.background(Color.appSecondaryButton)
-								.foregroundColor(.appTextPrimary)
-								.cornerRadius(12)
+							Image(systemName: "person.line.dotted.person.fill")
+								.font(.system(size: 18, weight: .semibold))
+								.frame(width: 52, height: 52)
+								.background(Color.duoThemAccent.opacity(0.14))
+								.foregroundStyle(Color.duoThemAccentDeep)
+								.clipShape(.rect(cornerRadius: 16, style: .continuous))
+								.overlay(
+									RoundedRectangle(cornerRadius: 16, style: .continuous)
+										.stroke(Color.duoThemAccent.opacity(0.24), lineWidth: 1)
+								)
 						}
 						.buttonStyle(.plain)
-
-						// Watch Ad Button (hidden when ad-free)
-						WatchAdButton {
-							showAdFreeToast = true
-							Task {
-								try? await Task.sleep(for: .seconds(2))
-								showAdFreeToast = false
-							}
-						}
+						.accessibilityLabel("Table Mode")
 					}
 					.padding(.horizontal, 16)
 					.padding(.bottom, 8)
@@ -185,6 +203,7 @@ struct TranslationScreen: View {
 
 					Spacer(minLength: 0)
 				}
+				.safeAreaPadding(.bottom, 12)
 				.onTapGesture {
 					isInputFocused = false
 				}
@@ -241,6 +260,90 @@ struct TranslationScreen: View {
 		}
 		viewModel.nativeText = sourceText
 		viewModel.translatedText = translatedText
+	}
+}
+
+// MARK: - DuoHeaderView
+
+private struct DuoHeaderView: View {
+	let onHistoryTapped: () -> Void
+	let onSettingsTapped: () -> Void
+
+	var body: some View {
+		HStack(spacing: 12) {
+			HStack(spacing: 0) {
+				Text("Talk")
+					.foregroundStyle(Color.duoTextPrimary)
+				Text("Trans")
+					.foregroundStyle(Color.duoThemAccent)
+			}
+
+			Spacer()
+
+			HStack(spacing: 8) {
+				Button(action: onHistoryTapped) {
+					Image(systemName: "clock.arrow.circlepath")
+						.font(.system(size: 14, weight: .semibold))
+						.foregroundStyle(Color.duoThemAccent)
+						.frame(width: 32, height: 32)
+						.background(Color.duoSurface, in: Circle())
+				}
+				.accessibilityLabel("Translation history")
+
+				Button(action: onSettingsTapped) {
+					Image(systemName: "gearshape")
+						.font(.system(size: 14, weight: .semibold))
+						.foregroundStyle(Color.duoYouAccent)
+						.frame(width: 32, height: 32)
+						.background(Color.duoSurface, in: Circle())
+				}
+				.accessibilityLabel("Settings")
+			}
+		}
+		.font(.system(size: 19, weight: .bold))
+		.accessibilityElement(children: .combine)
+		.accessibilityLabel("TalkTrans")
+	}
+}
+
+// MARK: - DuoModeSelectorView
+
+private struct DuoModeSelectorView: View {
+	let isSpeechSelected: Bool
+	let onTypeTapped: () -> Void
+	let onSpeakTapped: () -> Void
+
+	var body: some View {
+		HStack(spacing: 0) {
+			modeItem(title: "Type", systemImage: "keyboard", isSelected: !isSpeechSelected, action: onTypeTapped)
+			modeItem(title: "Speak", systemImage: "mic", isSelected: isSpeechSelected, action: onSpeakTapped)
+		}
+		.padding(3)
+		.background(Color.duoControlSurface.opacity(0.7), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+		.accessibilityLabel("Input mode")
+	}
+
+	private func modeItem(title: String, systemImage: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+		Button(action: action) {
+			HStack(spacing: 6) {
+				Image(systemName: systemImage)
+				Text(title.localized())
+			}
+			.font(.system(size: 13, weight: .semibold))
+			.foregroundStyle(isSelected ? Color.duoTextPrimary : Color.duoTextMuted)
+			.frame(maxWidth: .infinity)
+			.padding(.vertical, 8)
+			.background(
+				Group {
+					if isSelected {
+						RoundedRectangle(cornerRadius: 9, style: .continuous)
+							.fill(Color.duoSurface)
+					}
+				}
+			)
+		}
+		.buttonStyle(.plain)
+		.accessibilityAddTraits(isSelected ? [.isSelected] : [])
 	}
 }
 

--- a/Projects/App/Sources/Views/TranslationInputView.swift
+++ b/Projects/App/Sources/Views/TranslationInputView.swift
@@ -26,10 +26,6 @@ struct TranslationInputView: View {
 		"\(text.count) / \(maxLength)"
 	}
 
-	private var inputAreaHeight: CGFloat {
-		180
-	}
-	
 	var body: some View {
 		VStack(spacing: 0) {
 			HStack(spacing: 10) {
@@ -70,7 +66,7 @@ struct TranslationInputView: View {
 					.scrollContentBackground(.hidden)
 					.font(.system(size: 16))
 					.foregroundStyle(Color.duoTextSecondary)
-					.frame(height: inputAreaHeight)
+					.frame(maxHeight: .infinity)
 					.padding(.horizontal, 12)
 					.padding(.vertical, 8)
 					.focused(isFocused)
@@ -88,7 +84,7 @@ struct TranslationInputView: View {
 						.padding(.vertical, 12)
 				}
 			}
-			.frame(height: inputAreaHeight)
+			.frame(maxHeight: .infinity)
 
 		}
 		.background(Color.duoSurface)

--- a/Projects/App/Sources/Views/TranslationInputView.swift
+++ b/Projects/App/Sources/Views/TranslationInputView.swift
@@ -20,44 +20,57 @@ struct TranslationInputView: View {
 	let onSwap: () -> Void
 	let onHistoryTapped: () -> Void
 	let maxLength: Int
+	@State private var showLanguagePicker = false
+
+	private var counterText: String {
+		"\(text.count) / \(maxLength)"
+	}
+
+	private var inputAreaHeight: CGFloat {
+		180
+	}
 	
 	var body: some View {
 		VStack(spacing: 0) {
-            HStack{
-                // Language Picker
-                LanguagePickerButton(
-                    title: "Native Language:".localized(),
-                    locale: locale,
-                    availableLocales: availableLocales,
-                    onSelect: onLocaleChange
-                )
-                .padding(.horizontal, 16)
-                .padding(.top, 16)
-                .padding(.bottom, 12)
-                
+			HStack(spacing: 10) {
+				DuoInputFlagButton(locale: locale) {
+					showLanguagePicker = true
+				}
+
+				DuoRoleBadge(
+					locale: locale,
+					label: "\(locale.rawValue.uppercased()) · you",
+					accent: .duoYouAccent
+				)
+
 				Spacer()
-				
-				// Swap Button - calls onSwap closure when tapped
-				Button(action: {
-					onSwap()
-				}) {
-					Image(systemName: "arrow.left.arrow.right")
-						.font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.appAccent)
-                }.padding(.horizontal, 16)
-            }
+
+				Text(counterText)
+					.font(.system(size: 12))
+					.foregroundStyle(Color.duoTextMuted)
+			}
+			.sheet(isPresented: $showLanguagePicker) {
+				LanguageSelectionScreen(
+					languages: availableLocales,
+					selectedLocale: locale,
+					onSelect: onLocaleChange
+				)
+				.presentationDetents([.medium, .large])
+			}
+			.padding(.horizontal, 15)
+			.padding(.top, 15)
+			.padding(.bottom, 11)
 			
-			// Separator
 			Divider()
-				.padding(.horizontal, 16)
+				.overlay(Color.duoDivider.opacity(0.65))
+				.padding(.horizontal, 15)
 			
-			// Text Input
 			ZStack(alignment: .topLeading) {
 				TextEditor(text: $text)
 					.scrollContentBackground(.hidden)
 					.font(.system(size: 16))
-					.foregroundColor(.appTextPrimary)
-					.frame(minHeight: 100, maxHeight: 160)
+					.foregroundStyle(Color.duoTextSecondary)
+					.frame(height: inputAreaHeight)
 					.padding(.horizontal, 12)
 					.padding(.vertical, 8)
 					.focused(isFocused)
@@ -67,40 +80,58 @@ struct TranslationInputView: View {
 						}
 					}
                 
-                if text.isEmpty {
-                    Text(placeholder)
-                        .font(.system(size: 16))
-                        .foregroundColor(.appTextPlaceholder)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                }
-			}
-			HStack {
-				// History Button
-				Button(action: {
-					onHistoryTapped()
-				}) {
-					Image(systemName: "clock.arrow.circlepath")
-						.font(.system(size: 14, weight: .medium))
-						.foregroundColor(.appAccent)
-						.frame(width: 44, height: 44)
+				if text.isEmpty {
+					Text(placeholder)
+						.font(.system(size: 16))
+						.foregroundStyle(Color.duoTextMuted)
+						.padding(.horizontal, 16)
+						.padding(.vertical, 12)
 				}
-				.accessibilityLabel("Translation history")
-				.accessibilityHint("Opens list of previous translations")
-
-				Spacer()
-
-				Text("\(text.count)/\(maxLength)")
-					.font(.system(size: 12))
-					.foregroundColor(.appTextPlaceholder)
-					.padding(.trailing, 12)
-					.padding(.bottom, 4)
 			}
-			.padding(.horizontal, 16)
-			.padding(.bottom, 8)
+			.frame(height: inputAreaHeight)
+
 		}
-		.background(Color.appInputOutputBackground)
-		.cornerRadius(16)
+		.background(Color.duoSurface)
+		.overlay(
+			RoundedRectangle(cornerRadius: 20, style: .continuous)
+				.stroke(Color.duoYouAccent.opacity(0.22), lineWidth: 1)
+		)
+		.clipShape(.rect(cornerRadius: 20, style: .continuous))
+	}
+}
+
+// MARK: - DuoRoleBadge
+
+private struct DuoRoleBadge: View {
+	let locale: TranslationLocale
+	let label: String
+	let accent: Color
+
+	var body: some View {
+		Text(label.localized())
+			.font(.system(size: 15, weight: .semibold))
+			.foregroundStyle(accent)
+			.lineLimit(2)
+	}
+}
+
+private struct DuoInputFlagButton: View {
+	let locale: TranslationLocale
+	let action: () -> Void
+
+	var body: some View {
+		Button(action: action) {
+			if let flagImage = UIImage(named: locale.flagImageName) {
+				Image(uiImage: flagImage)
+					.resizable()
+					.scaledToFill()
+					.frame(width: 34, height: 24)
+					.clipShape(.rect(cornerRadius: 4, style: .continuous))
+			}
+		}
+		.frame(width: 48, height: 38)
+		.background(Color.duoYouAccent.opacity(0.12), in: Capsule())
+		.accessibilityLabel("Native Language:".localized())
 	}
 }
 
@@ -121,4 +152,3 @@ struct TranslationInputView: View {
     .frame(height: 100)
     .padding()
 }
-

--- a/Projects/App/Sources/Views/TranslationOutputView.swift
+++ b/Projects/App/Sources/Views/TranslationOutputView.swift
@@ -17,10 +17,10 @@ struct TranslationOutputView: View {
 	let isFullScreen: Bool
 	let onToggleFullScreen: () -> Void
 	let deviceOrientation: UIDeviceOrientation
-	@State private var rotationAngle: Double = LSDefaults.translationOutputRotationAngle
 	@State private var fontSize: CGFloat = LSDefaults.translationOutputFontSize
 	@State private var magnification: CGFloat = 1.0
 	@State private var isFontSizeSheetPresented: Bool = false
+	@State private var showLanguagePicker = false
 
 	// Computed property for effective font size with constraints
 	private var effectiveFontSize: CGFloat {
@@ -30,36 +30,39 @@ struct TranslationOutputView: View {
 
 	// Computed property for rotation angle based on device orientation
 	private var effectiveRotationAngle: Double {
-		// Disable rotation in landscape mode
-		deviceOrientation.isLandscape ? 0 : rotationAngle
+		// Duo Table Mode stays upright; the old manual rotation control is removed.
+		0
+	}
+
+	private var textAreaHeight: CGFloat? {
+		isFullScreen ? nil : 170
 	}
 
 	var body: some View {
 		VStack(spacing: 0) {
-			HStack {
-				// Language Picker
-				LanguagePickerButton(
-					title: "Translated Language:".localized(),
+			HStack(spacing: 10) {
+				DuoOutputFlagButton(locale: locale) {
+					showLanguagePicker = true
+				}
+
+				DuoOutputRoleBadge(
 					locale: locale,
-					availableLocales: availableLocales,
-					onSelect: onLocaleChange
+					label: "\(locale.rawValue.uppercased()) · for them",
+					accent: .duoThemAccent
 				)
-				.padding(.horizontal, 16)
-				.padding(.top, 16)
-				.padding(.bottom, 12)
 
 				Spacer()
 
-				// Font Size Button
 				Button(action: {
 					isFontSizeSheetPresented = true
 				}) {
 					Image(systemName: "textformat.size")
 						.font(.system(size: 14, weight: .medium))
-						.foregroundColor(.appAccent)
+						.foregroundStyle(Color.duoThemAccent)
+						.frame(width: 32, height: 32)
+						.background(Color.duoThemAccent.opacity(0.12), in: Circle())
 				}
 				.rotationEffect(.degrees(-effectiveRotationAngle))
-				.padding(.trailing, 8)
 				.sheet(isPresented: $isFontSizeSheetPresented) {
 					FontSizeSheetView(fontSize: $fontSize)
 						.presentationDetents([.height(220)])
@@ -71,49 +74,36 @@ struct TranslationOutputView: View {
 					ShareLink(item: text) {
 						Image(systemName: "square.and.arrow.up")
 							.font(.system(size: 14, weight: .medium))
-							.foregroundColor(.appAccent)
+							.foregroundStyle(Color.duoThemAccent)
+							.frame(width: 32, height: 32)
+							.background(Color.duoThemAccent.opacity(0.12), in: Circle())
 					}
 					.rotationEffect(.degrees(-effectiveRotationAngle))
-					.padding(.trailing, 8)
 				}
 
-				// Rotate Button - rotates entire view 180 degrees when tapped
-				Button(action: {
-					let newAngle = rotationAngle + 180
-					withAnimation(.easeInOut(duration: 0.3)) {
-						rotationAngle = newAngle
-					}
-					LSDefaults.translationOutputRotationAngle = newAngle
-				}) {
-					if effectiveRotationAngle.truncatingRemainder(dividingBy: 360) != 0 {
-						Image(systemName: "pin.fill")
-							.font(.system(size: 14, weight: .medium))
-							.foregroundColor(.appAccent)
-							.rotationEffect(.degrees(45))
-					} else {
-						Image(systemName: "arrow.triangle.2.circlepath")
-							.font(.system(size: 14, weight: .medium))
-							.foregroundColor(.appAccent)
-					}
-				}
-				.disabled(deviceOrientation.isLandscape) // Disable rotation button in landscape
-				.opacity(deviceOrientation.isLandscape ? 0.5 : 1.0) // Visual feedback for disabled state
-				.accessibilityHint(deviceOrientation.isLandscape ? "Rotation is disabled in landscape mode" : "")
-				.rotationEffect(.degrees(-effectiveRotationAngle))
-				.padding(.horizontal, 16)
 			}
+			.sheet(isPresented: $showLanguagePicker) {
+				LanguageSelectionScreen(
+					languages: availableLocales,
+					selectedLocale: locale,
+					onSelect: onLocaleChange
+				)
+				.presentationDetents([.medium, .large])
+			}
+			.padding(.horizontal, 15)
+			.padding(.top, 15)
+			.padding(.bottom, 11)
 
-			// Separator
 			Divider()
-				.padding(.horizontal, 16)
+				.overlay(Color.duoDivider.opacity(0.65))
+				.padding(.horizontal, 15)
 
-			// Translated Text
 			ZStack(alignment: .bottomTrailing) {
 				ZStack(alignment: .topLeading) {
 					if text.isEmpty {
 						Text(placeholder)
 							.font(.system(size: effectiveFontSize))
-							.foregroundColor(.appTextPlaceholder)
+							.foregroundStyle(Color.duoTextMuted)
 							.padding(.horizontal, 16)
 							.padding(.vertical, 12)
 					}
@@ -121,7 +111,7 @@ struct TranslationOutputView: View {
 					ScrollView {
 						Text(text)
 							.font(.system(size: effectiveFontSize))
-							.foregroundColor(.appTextPrimary)
+							.foregroundStyle(Color.duoTextPrimary)
 							.frame(maxWidth: .infinity, alignment: .leading)
 							.padding(.horizontal, 16)
 							.padding(.vertical, 12)
@@ -141,30 +131,53 @@ struct TranslationOutputView: View {
 						}
 				)
 
-				// Full Screen Toggle Button
-				Button(action: {
-					onToggleFullScreen()
-				}) {
-					Image(systemName: isFullScreen ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
-						.font(.system(size: 14, weight: .medium))
-						.foregroundColor(.appAccent)
-						.padding(8)
-						.background(
-							Circle()
-								.fill(Color.appInputOutputBackground.opacity(0.8))
-								.shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
-						)
-				}
-				.rotationEffect(.degrees(-effectiveRotationAngle))
-				.padding(.trailing, 12)
-				.padding(.bottom, 12)
 			}
 			.padding(.horizontal, 16)
 			.padding(.bottom, 16)
+			.frame(height: textAreaHeight)
 		}
-		.background(Color.appInputOutputBackground)
-		.cornerRadius(16)
+		.background(Color.duoElevatedSurface)
+		.overlay(
+			RoundedRectangle(cornerRadius: 20, style: .continuous)
+				.stroke(Color.duoThemAccent.opacity(0.24), lineWidth: 1)
+		)
+		.clipShape(.rect(cornerRadius: 20, style: .continuous))
 		.rotationEffect(.degrees(effectiveRotationAngle))
+	}
+}
+
+// MARK: - DuoOutputRoleBadge
+
+private struct DuoOutputRoleBadge: View {
+	let locale: TranslationLocale
+	let label: String
+	let accent: Color
+
+	var body: some View {
+		Text(label.localized())
+			.font(.system(size: 15, weight: .semibold))
+			.foregroundStyle(accent)
+			.lineLimit(2)
+	}
+}
+
+private struct DuoOutputFlagButton: View {
+	let locale: TranslationLocale
+	let action: () -> Void
+
+	var body: some View {
+		Button(action: action) {
+			if let flagImage = UIImage(named: locale.flagImageName) {
+				Image(uiImage: flagImage)
+					.resizable()
+					.scaledToFill()
+					.frame(width: 34, height: 24)
+					.clipShape(.rect(cornerRadius: 4, style: .continuous))
+			}
+		}
+		.frame(width: 48, height: 38)
+		.background(Color.duoThemAccent.opacity(0.12), in: Capsule())
+		.accessibilityLabel("Translated Language:".localized())
 	}
 }
 

--- a/Projects/App/Sources/Views/TranslationOutputView.swift
+++ b/Projects/App/Sources/Views/TranslationOutputView.swift
@@ -34,10 +34,6 @@ struct TranslationOutputView: View {
 		0
 	}
 
-	private var textAreaHeight: CGFloat? {
-		isFullScreen ? nil : 170
-	}
-
 	var body: some View {
 		VStack(spacing: 0) {
 			HStack(spacing: 10) {
@@ -134,7 +130,7 @@ struct TranslationOutputView: View {
 			}
 			.padding(.horizontal, 16)
 			.padding(.bottom, 16)
-			.frame(height: textAreaHeight)
+			.frame(maxHeight: .infinity)
 		}
 		.background(Color.duoElevatedSurface)
 		.overlay(

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -22,11 +22,15 @@ struct WatchAdButton: View {
 				showConfirmation = true
 			}) {
 				Image(systemName: "gift")
-					.font(.system(size: 14, weight: .medium))
-					.frame(width: 50, height: 50)
-					.background(Color.appSecondaryButton)
-					.foregroundColor(.appAccent)
-					.cornerRadius(12)
+					.font(.system(size: 18, weight: .semibold))
+					.frame(width: 52, height: 52)
+					.background(Color.duoYouAccent.opacity(0.14))
+					.foregroundStyle(Color.duoYouAccentDeep)
+					.clipShape(.rect(cornerRadius: 16, style: .continuous))
+					.overlay(
+						RoundedRectangle(cornerRadius: 16, style: .continuous)
+							.stroke(Color.duoYouAccent.opacity(0.24), lineWidth: 1)
+					)
 			}
 			.buttonStyle(.plain)
 			.transition(.opacity.combined(with: .scale(scale: 0.8)))

--- a/design.md
+++ b/design.md
@@ -100,8 +100,26 @@ Design requirements:
 - Input card uses you-accent border and label: `KO · you`.
 - Character counter remains visible in the input card: `32 / 500`.
 - Primary CTA remains a large bottom `Translate` button.
-- Reward/ad-free button remains a square secondary CTA with gift styling.
+- Reward/ad-free button uses square amber gift styling when shown, but remains hidden in the current main CTA row pass.
 - Suggested phrases appear as horizontal chips under input/output when useful.
+
+Current implementation refinement rule:
+- The main portrait screen must read as a **compact conversation pair**, not two large blank panels.
+- Empty-state output and input cards should size to their content plus a practical writing area; do not let `ScrollView` or `TextEditor` consume all vertical space.
+- On tall phones, use explicit portrait caps until the layout is fully responsive: output card about 240–260pt, input card about 300–320pt. Extra height should remain as breathing room around the seam CTA, not inside blank cards.
+- Place the Table Mode entry on the seam between output and input. In the light design this appears as a centered teal circular CTA with a small `Table Mode` caption; in dark mode it may be a teal CTA between the cards.
+- The full-screen/rotation affordance should not visually dominate the normal output card; reserve rotation for full-screen/Table-style presentation.
+- Keep the banner visible as a full-width adaptive placement between the output and input cards in the normal portrait composition when ads are enabled. It should align with the card margins and must not force content into the status or home indicator areas.
+- Tighten the vertical rhythm around the output card, banner, and input card. The banner should sit visually between the two cards with only a small breathing gap, and the primary CTA row must remain above the home indicator safe area.
+- Main header must use right-top circular **history** and **settings** buttons; do not leave a blank navigation/header area.
+- Language controls in the main cards should show only the flag as the tappable framed language affordance. Do not frame the role text (`EN · for them`, `KO · you`) and do not show a chevron/dropdown beside it in the card.
+- Language role text should be prominent enough to match the design; use about 15pt semibold for `EN · for them` and `KO · you` labels.
+- Remove the normal-card language swap button from the input card.
+- Use `person.line.dotted.person.fill` for the Table Mode affordance because it communicates face-to-face translation better than a literal furniture icon. Remove the old rotate/full-screen button from the output card controls.
+- Hide the gift/reward button in the main CTA row for this pass. Place the Table Mode button to the right of the Translate CTA as a square secondary action.
+- Put the input character count at the top-right of the input text area, aligned with the right edge of the input flag row.
+- Remove the bottom microphone action from the main action row; speech remains accessible through the mode control/speech flow.
+- Translate CTA should use the design teal gradient and gift/reward CTA should use the design amber/gift styling.
 
 Approximate sizing:
 - Screen horizontal padding: 16pt.

--- a/design.md
+++ b/design.md
@@ -105,8 +105,8 @@ Design requirements:
 
 Current implementation refinement rule:
 - The main portrait screen must read as a **compact conversation pair**, not two large blank panels.
-- Empty-state output and input cards should size to their content plus a practical writing area; do not let `ScrollView` or `TextEditor` consume all vertical space.
-- On tall phones, use explicit portrait caps until the layout is fully responsive: output card about 240–260pt, input card about 300–320pt. Extra height should remain as breathing room around the seam CTA, not inside blank cards.
+- Empty-state output and input cards should share the available vertical space equally; do not hard-code separate input/output card heights.
+- On tall phones, the output and input cards should fill equally after fixed elements such as header, mode control, banner, and CTA row are laid out.
 - Place the Table Mode entry on the seam between output and input. In the light design this appears as a centered teal circular CTA with a small `Table Mode` caption; in dark mode it may be a teal CTA between the cards.
 - The full-screen/rotation affordance should not visually dominate the normal output card; reserve rotation for full-screen/Table-style presentation.
 - Keep the banner visible as a full-width adaptive placement between the output and input cards in the normal portrait composition when ads are enabled. It should align with the card margins and must not force content into the status or home indicator areas.


### PR DESCRIPTION
## Summary
- Apply Duo-inspired main translation screen with semantic light/dark color tokens
- Add flag-only language controls, larger role labels, compact cards, and right-top history/settings actions
- Restore full-width adaptive banner between output and input cards
- Move Table Mode to the CTA row and hide the gift CTA in the main row

## User flow
```mermaid
flowchart TD
  A[Open TalkTrans] --> B[Main Duo translation screen]
  B --> C[Choose Type or Speak]
  B --> D[Tap flag-only language control]
  D --> E[Language selection sheet]
  B --> F[Tap Translate]
  F --> G[Translated output updates]
  B --> H[Tap Table Mode]
  H --> I[Full-screen table mode]
```

## Verification
- [x] `mise x -- tuist build`
- [x] Installed and launched on iPhone 11 Pro Max simulator
- [x] Captured screenshot: `/var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/talktrans-duo-table-cta-no-gift.png`

## Risks / notes
- Settings button is present but currently no-op; no existing settings screen was found.
- Banner uses adaptive width and remains hidden for ad-free users.

## Result
<img width="606" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-02 at 20 37 06" src="https://github.com/user-attachments/assets/b67c5d8b-d0f1-44e4-af3d-c4383d339d52" />