### PR TITLE
feat: redesign Speak Mode voice input

### DIFF
--- a/Projects/App/Sources/Models/TranslationLocale+Extension.swift
+++ b/Projects/App/Sources/Models/TranslationLocale+Extension.swift
@@ -44,6 +44,24 @@ extension TranslationLocale {
 		case .france: return "french"
 		}
 	}
+
+	var flagEmoji: String {
+		switch self {
+		case .korean: return "🇰🇷"
+		case .japanese: return "🇯🇵"
+		case .english: return "🇺🇸"
+		case .taiwan: return "🇹🇼"
+		case .chinese: return "🇨🇳"
+		case .vietnam: return "🇻🇳"
+		case .indonesian: return "🇮🇩"
+		case .thai: return "🇹🇭"
+		case .german: return "🇩🇪"
+		case .russian: return "🇷🇺"
+		case .spain: return "🇪🇸"
+		case .italian: return "🇮🇹"
+		case .france: return "🇫🇷"
+		}
+	}
 	
 	var locale: Locale {
 		return Locale(identifier: self.rawValue)
@@ -72,4 +90,3 @@ extension TranslationLocale {
 		}
 	}
 }
-

--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -7,106 +7,208 @@
 import SwiftUI
 
 struct SpeechRecognitionScreen: View {
-    @ObservedObject var viewModel: SpeechRecognitionViewModel
-    @Binding var text: String
-    @Environment(\.dismiss) private var dismiss
-    let locale: Locale
-    var processTitle: String?
-    var onProcess: (() -> Void)?
-    
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("Recognizing...")
-                .font(.system(size: 20, weight: .semibold))
-                .padding(.top, 20)
-            
-            Text("Please say sentence to be recognized")
-                .font(.system(size: 16))
-                .foregroundColor(.secondary)
-            
-            if viewModel.isRecognizing {
-                ProgressView()
-                    .scaleEffect(1.5)
-                    .padding()
-            }
-            
-            if !viewModel.recognizedText.isEmpty {
-                Text(viewModel.recognizedText)
-                    .font(.system(size: 16))
-                    .foregroundColor(.primary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
-                    .lineLimit(3)
-            }
-            
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .font(.system(size: 14))
-                    .foregroundColor(.red)
-                    .padding(.horizontal, 20)
-            }
-            
-            HStack(spacing: 12) {
-                Button(action: {
-                    if !viewModel.recognizedText.isEmpty {
-                        text = viewModel.recognizedText
-                    }
-                    viewModel.stopRecognition()
-                    dismiss()
-                }) {
-                    Text("Done")
-                        .font(.system(size: 17, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color.gray.opacity(0.2))
-                        .foregroundColor(.primary)
-                        .cornerRadius(12)
-                }
-                
-                if let onProcess, let processTitle {
-                    Button(action: {
-                        if !viewModel.recognizedText.isEmpty {
-                            text = viewModel.recognizedText
-                        }
-                        viewModel.stopRecognition()
-                        onProcess()
-                        dismiss()
-                    }) {
-                        Text(processTitle)
-                            .font(.system(size: 17, weight: .semibold))
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 50)
-                            .background(
-                                LinearGradient(
-                                    colors: [
-                                        .appAccentGradientStart,
-                                        .appAccentGradientEnd
-                                    ],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .foregroundColor(.white)
-                            .cornerRadius(12)
-                    }
-                }
-            }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
-        }
-        .presentationDetents([.height(250)])
-        .onChange(of: viewModel.recognizedText) { _, newValue in
-            if !newValue.isEmpty {
-                text = newValue
-            }
-        }
-        .onAppear {
-            viewModel.startRecognition(locale: locale) { _ in
-                // Text will be updated via recognizedText in viewModel
-            }
-        }
-        .onDisappear {
-            viewModel.stopRecognition()
-        }
-    }
+	@ObservedObject var viewModel: SpeechRecognitionViewModel
+	@Binding var text: String
+	let sourceLocale: TranslationLocale
+	let targetLocale: TranslationLocale
+	var processTitle: String?
+	var onProcess: (() -> Void)?
+	var onCancel: (() -> Void)?
+
+	var body: some View {
+		ZStack {
+			LinearGradient(
+				colors: [
+					.duoBackground,
+					.duoBackground,
+					.duoYouAccent.opacity(0.05),
+					.duoThemAccent.opacity(0.04)
+				],
+				startPoint: .top,
+				endPoint: .bottom
+			)
+			.ignoresSafeArea()
+
+			VStack(spacing: 0) {
+				speakerPill
+					.frame(maxWidth: .infinity, alignment: .leading)
+					.padding(.horizontal, 44)
+					.padding(.top, 50)
+
+				Spacer(minLength: 132)
+
+				microphoneButton
+
+				recognizedText
+					.padding(.top, 76)
+
+				if let errorMessage = viewModel.errorMessage {
+					errorMessageView(errorMessage)
+						.padding(.top, 18)
+						.padding(.horizontal, 40)
+				}
+
+				Spacer(minLength: 34)
+
+				actionButtons
+					.padding(.horizontal, 32)
+					.padding(.bottom, 64)
+			}
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+		}
+		.onChange(of: viewModel.recognizedText) { _, newValue in
+			if !newValue.isEmpty {
+				text = newValue
+			}
+		}
+		.onAppear {
+			viewModel.resetSessionState()
+			startRecognition()
+		}
+		.onDisappear {
+			viewModel.stopRecognition()
+		}
+	}
+
+	private var speakerPill: some View {
+		HStack(spacing: 10) {
+			Text(sourceLocale.flagEmoji)
+				.font(.system(size: 15))
+
+			Text(verbatim: "Speaking \(sourceLocale.displayName)")
+				.font(.system(size: 17, weight: .bold))
+				.foregroundStyle(Color.duoYouAccentDeep)
+		}
+		.padding(.horizontal, 18)
+		.padding(.vertical, 12)
+		.background(Color.duoYouAccent.opacity(0.13))
+		.clipShape(.capsule)
+		.accessibilityElement(children: .combine)
+		.accessibilityLabel("Speaking \(sourceLocale.displayName)")
+	}
+
+	private var microphoneButton: some View {
+		Button(action: toggleRecognition) {
+			ZStack {
+				Circle()
+					.fill(Color.duoYouAccent.opacity(0.08))
+					.frame(width: 178, height: 178)
+					.overlay(
+						Circle()
+							.stroke(Color.duoYouAccent.opacity(0.28), lineWidth: 1.5)
+					)
+					.scaleEffect(viewModel.isRecognizing ? 1.08 : 1)
+
+				Circle()
+					.fill(
+						LinearGradient(
+							colors: [.duoYouAccent, .duoYouAccentDeep],
+							startPoint: .top,
+							endPoint: .bottom
+						)
+					)
+					.frame(width: 118, height: 118)
+					.shadow(color: Color.duoYouAccent.opacity(0.28), radius: 20, y: 12)
+
+				Image(systemName: viewModel.isRecognizing ? "stop.fill" : "mic.fill")
+					.font(.system(size: 44, weight: .semibold))
+					.foregroundStyle(.white)
+			}
+			.animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: viewModel.isRecognizing)
+		}
+		.buttonStyle(.plain)
+		.accessibilityLabel(viewModel.isRecognizing ? "Stop listening" : "Start listening")
+	}
+
+	private var recognizedText: some View {
+		Text(displayText)
+			.font(.system(size: 30, weight: .bold))
+			.foregroundStyle(text.isEmpty ? Color.duoTextMuted : Color.duoTextPrimary)
+			.multilineTextAlignment(.center)
+			.lineSpacing(8)
+			.frame(maxWidth: .infinity)
+			.padding(.horizontal, 56)
+			.accessibilityLabel(text.isEmpty ? "No recognized text yet" : "Recognized text: \(text)")
+	}
+
+	private var actionButtons: some View {
+		HStack(spacing: 20) {
+			Button(action: cancel) {
+				Text(verbatim: "Cancel")
+					.font(.system(size: 18, weight: .bold))
+					.frame(maxWidth: .infinity)
+					.frame(height: 64)
+					.background(Color.duoControlSurface)
+					.foregroundStyle(Color.duoTextSecondary)
+					.clipShape(.rect(cornerRadius: 18, style: .continuous))
+			}
+
+			if let onProcess, let processTitle {
+				Button(action: {
+					viewModel.stopRecognition()
+					onProcess()
+				}) {
+					Text(verbatim: processTitle)
+						.font(.system(size: 18, weight: .bold))
+						.frame(maxWidth: .infinity)
+						.frame(height: 64)
+						.background(
+							LinearGradient(
+								colors: [.duoThemAccent, .duoThemAccentDeep],
+								startPoint: .leading,
+								endPoint: .trailing
+							)
+						)
+						.foregroundStyle(.white)
+						.clipShape(.rect(cornerRadius: 18, style: .continuous))
+				}
+				.disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+				.opacity(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.72 : 1)
+			}
+		}
+	}
+
+	private var displayText: String {
+		let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+		if !trimmedText.isEmpty {
+			return trimmedText
+		}
+
+		if viewModel.errorMessage != nil {
+			return "Tap mic to try again"
+		}
+
+		return "Listening…"
+	}
+
+	private func errorMessageView(_ message: String) -> some View {
+		Text(message)
+			.font(.system(size: 14, weight: .semibold))
+			.foregroundStyle(Color.duoYouAccentDeep)
+			.multilineTextAlignment(.center)
+			.padding(14)
+			.frame(maxWidth: .infinity)
+			.background(Color.duoYouAccent.opacity(0.12))
+			.clipShape(.rect(cornerRadius: 16, style: .continuous))
+	}
+
+	private func toggleRecognition() {
+		if viewModel.isRecognizing {
+			viewModel.stopRecognition()
+			return
+		}
+
+		startRecognition()
+	}
+
+	private func startRecognition() {
+		viewModel.startRecognition(locale: sourceLocale.locale) { _ in
+			// Text is mirrored through recognizedText onChange.
+		}
+	}
+
+	private func cancel() {
+		viewModel.stopRecognition()
+		onCancel?()
+	}
 }

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -88,7 +88,7 @@ struct TranslationScreen: View {
 						.padding(.horizontal, 16)
 
 					// Translated Output Section
-					if !showSpeechRecognition && !isInputFocused {
+					if !isInputFocused {
 						TranslationOutputView(
 							text: viewModel.translatedText,
 							locale: viewModel.translatedLocale,
@@ -220,14 +220,20 @@ struct TranslationScreen: View {
 		.translationTask(viewModel.translationConfiguration) { [sessionBindingRequestID] session in
 			await viewModel.setTranslationSession(session, for: sessionBindingRequestID)
 		}
-		.sheet(isPresented: $showSpeechRecognition) {
+		.fullScreenCover(isPresented: $showSpeechRecognition) {
 			SpeechRecognitionScreen(
 				viewModel: speechViewModel,
 				text: $viewModel.nativeText,
-				locale: viewModel.nativeLocale.locale,
-				processTitle: "Translate",
+				sourceLocale: viewModel.nativeLocale,
+				targetLocale: viewModel.translatedLocale,
+				processTitle: "Use & translate",
 				onProcess: {
+					isInputFocused = false
+					showSpeechRecognition = false
 					viewModel.translate()
+				},
+				onCancel: {
+					showSpeechRecognition = false
 				}
 			)
 		}

--- a/design.md
+++ b/design.md
@@ -136,13 +136,17 @@ Current mapping:
 - `Projects/App/Sources/ViewModels/SpeechRecognitionViewModel.swift`
 
 Design requirements:
-- Full-screen or sheet-like focused listening state.
-- Speaker pill at top-left: `Speaking Korean`, using you-accent.
-- Large centered circular mic control with concentric rings.
-- Recognized text centered below mic.
-- Bottom actions:
-  - `Cancel` secondary.
-  - `Use & translate` primary with them-accent gradient.
+- Voice input is a **dedicated full-screen capture screen**, not a partial-height sheet.
+- Present from the `Speak` segment as an immersive flow; hide the main TalkTrans header, segmented control, cards, and ads while voice capture is active.
+- Hide banner ads while Speak mode is active; do not place ads near the microphone or let ads shift listening controls.
+- Show a top-left speaker pill: flag + `Speaking Korean`, using you-accent tint.
+- Large centered circular mic control with warm you-accent/orange gradient and subtle concentric ring.
+- It may begin listening immediately on entry, as long as the listening state is visually obvious and Cancel is always available.
+- Recognized text is centered below the mic in large bold type.
+- Inline error card for unavailable recognizer, permission denial, or no speech; always offer a path back to Type.
+- Bottom actions by state:
+  - `Cancel` secondary on the left.
+  - `Use & translate` primary with them-accent gradient on the right.
 
 Approximate sizing:
 - Mic orbit: 172pt.


### PR DESCRIPTION
## Goal
Redesign Speak Mode voice input from a small sheet into a dedicated full-screen capture flow matching the Duo design direction.

## User flow
```mermaid
flowchart TD
  A[Main translation screen] --> B[Tap Speak segment]
  B --> C[Full-screen voice capture]
  C --> D[Speech recognition starts]
  D --> E{Recognized text?}
  E -->|Yes| F[Use & translate]
  F --> G[Return to main screen and translate]
  E -->|No / error| H[Show retry/error text]
  H --> C
  C --> I[Cancel]
  I --> A
```

## Changes
- Replaces the speech sheet with a `fullScreenCover`.
- Restyles `SpeechRecognitionScreen` as an immersive Duo voice capture screen.
- Adds source-language speaker pill, orange mic orb, centered transcript/error text, and bottom `Cancel` / `Use & translate` actions.
- Adds `TranslationLocale.flagEmoji` for reliable flag display in minimal voice UI.
- Updates `design.md` with the final full-screen Speak Mode direction.

## Verification
- `mise x -- tuist build` ✅

## Risks / notes
- Simulator may show `Failed to initialize recognizer` depending on speech recognizer availability; layout supports inline error/retry state.
- `.package.resolved` changes from Tuist build were restored and are not included.

## Result
<img width="1242" height="2688" alt="Simulator Screenshot - iPhone 11 Pro Max - 2026-07-03 at 09 33 41" src="https://github.com/user-attachments/assets/35d54d56-a7cf-4c02-8c64-ac1a1e015e9e" />
