### PR TITLE
fix: mock Speak Mode text on simulator

### DIFF
--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -42,7 +42,7 @@ struct SpeechRecognitionScreen: View {
 				recognizedText
 					.padding(.top, 76)
 
-				if let errorMessage = viewModel.errorMessage {
+				if shouldShowErrorMessage, let errorMessage = viewModel.errorMessage {
 					errorMessageView(errorMessage)
 						.padding(.top, 18)
 						.padding(.horizontal, 40)
@@ -63,7 +63,11 @@ struct SpeechRecognitionScreen: View {
 		}
 		.onAppear {
 			viewModel.resetSessionState()
+			#if targetEnvironment(simulator)
+			applySimulatorScreenshotMock()
+			#else
 			startRecognition()
+			#endif
 		}
 		.onDisappear {
 			viewModel.stopRecognition()
@@ -168,6 +172,14 @@ struct SpeechRecognitionScreen: View {
 		}
 	}
 
+	private var shouldShowErrorMessage: Bool {
+		#if targetEnvironment(simulator)
+		return false
+		#else
+		return true
+		#endif
+	}
+
 	private var displayText: String {
 		let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
 		if !trimmedText.isEmpty {
@@ -193,12 +205,17 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private func toggleRecognition() {
+		#if targetEnvironment(simulator)
+		applySimulatorScreenshotMock()
+		return
+		#else
 		if viewModel.isRecognizing {
 			viewModel.stopRecognition()
 			return
 		}
 
 		startRecognition()
+		#endif
 	}
 
 	private func startRecognition() {
@@ -206,6 +223,18 @@ struct SpeechRecognitionScreen: View {
 			// Text is mirrored through recognizedText onChange.
 		}
 	}
+
+	#if targetEnvironment(simulator)
+	private func applySimulatorScreenshotMock() {
+		let mockText = "가장 가까운 지하철역이\n어디예요?"
+		viewModel.stopRecognition()
+		viewModel.errorMessage = nil
+		viewModel.recognizedText = mockText
+		text = mockText
+	}
+	#else
+	private func applySimulatorScreenshotMock() { }
+	#endif
 
 	private func cancel() {
 		viewModel.stopRecognition()


### PR DESCRIPTION
## Goal
Make Speak Mode screenshot capture reliable on Simulator without depending on live speech recognition.

## User flow
```mermaid
flowchart TD
  A[Tap Speak] --> B{Running on Simulator?}
  B -->|Yes| C[Apply mock Korean transcript]
  B -->|No| D[Start real speech recognition]
  C --> E[Clean screenshot state]
  D --> F[Real voice input]
```

## Changes
- Uses `#if targetEnvironment(simulator)` for simulator-only mock behavior.
- Skips real speech recognition on Simulator.
- Applies the Korean mock transcript immediately for screenshot capture.
- Hides speech error message on Simulator mock state.
- Keeps real speech recognition unchanged on physical devices.

## Verification
- `mise x -- tuist build` ✅

## Notes
- `.package.resolved` changes caused by Tuist build were restored and are not included.

## Result
<img width="642"  alt="Simulator Screenshot - iPhone 11 Pro Max - 2026-07-03 at 11 39 24" src="https://github.com/user-attachments/assets/b91ba6b2-13cc-4408-8ff7-bf95991ff8ce" />
