### PR TITLE
Redesign Table Mode hero

### DIFF
--- a/Projects/App/Sources/Extensions/Color+App.swift
+++ b/Projects/App/Sources/Extensions/Color+App.swift
@@ -64,6 +64,30 @@ extension Color {
 		Color.dynamic(light: 0xD2D8E0, dark: 0x2A303C)
 	}
 
+	static var duoTableThemBackground: Color {
+		Color.dynamic(light: 0xDDF7F2, dark: 0x0E3D37)
+	}
+
+	static var duoTableThemBackgroundDeep: Color {
+		Color.dynamic(light: 0xC9F0E9, dark: 0x0C2E2A)
+	}
+
+	static var duoTableYouBackground: Color {
+		Color.dynamic(light: 0xFDEFD6, dark: 0x2E2410)
+	}
+
+	static var duoTableYouBackgroundDeep: Color {
+		Color.dynamic(light: 0xFCE4BE, dark: 0x191007)
+	}
+
+	static var duoTableThemText: Color {
+		Color.dynamic(light: 0x093E38, dark: 0xEAFBF7)
+	}
+
+	static var duoTableYouText: Color {
+		Color.dynamic(light: 0x4A3208, dark: 0xFBF3E6)
+	}
+
 	private static func dynamic(light: UInt, dark: UInt) -> Color {
 		Color(uiColor: UIColor { traitCollection in
 			uiColor(hex: traitCollection.userInterfaceStyle == .dark ? dark : light)

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -47,30 +47,19 @@ struct TranslationScreen: View {
 			.ignoresSafeArea()
 
 			if viewModel.isFullScreen {
-				// Full Screen Mode - Only show translated output
-				VStack(spacing: 0) {
-					TranslationOutputView(
-						text: viewModel.translatedText,
-						locale: viewModel.translatedLocale,
-						sourceLocale: viewModel.nativeLocale,
-						availableLocales: viewModel.supportedTargetLocales,
-						placeholder: "Translated message will appear here".localized(),
-						onLocaleChange: { locale in
-							viewModel.updateTranslatedLocale(locale)
-						},
-						isFullScreen: viewModel.isFullScreen,
-						onToggleFullScreen: {
-							viewModel.toggleFullScreen()
-						},
-						deviceOrientation: viewModel.deviceOrientation
-					)
-					.padding(16)
-
-					if !SwiftUIAdManager.isDisabled, !adManager.isAdFree {
-						BannerAdSwiftUIView()
-							.frame(height: 50)
+				DuoTableModeView(
+					sourceText: viewModel.nativeText,
+					translatedText: viewModel.translatedText,
+					sourceLocale: viewModel.nativeLocale,
+					targetLocale: viewModel.translatedLocale,
+					onExit: {
+						viewModel.toggleFullScreen()
+					},
+					onSpeakToReply: {
+						showSpeechRecognition = true
 					}
-				}.transition(.scale)
+				)
+				.transition(.scale)
 			} else {
 				// Normal Mode - Show all UI elements
 				VStack(spacing: 8) {
@@ -212,6 +201,7 @@ struct TranslationScreen: View {
 				.transition(.scale)
 			}
 		}
+		.statusBarHidden(viewModel.isFullScreen)
 		.onChange(of: viewModel.lastCompletedTranslationID) { _, newValue in
 			guard let translationID = newValue else { return }
 			guard translationID != lastHandledTranslationID else { return }
@@ -268,6 +258,163 @@ struct TranslationScreen: View {
 		}
 		viewModel.nativeText = sourceText
 		viewModel.translatedText = translatedText
+	}
+}
+
+// MARK: - DuoTableModeView
+
+private struct DuoTableModeView: View {
+	let sourceText: String
+	let translatedText: String
+	let sourceLocale: TranslationLocale
+	let targetLocale: TranslationLocale
+	let onExit: () -> Void
+	let onSpeakToReply: () -> Void
+
+	var body: some View {
+		GeometryReader { proxy in
+			VStack(spacing: 0) {
+				DuoTableModePanel(
+					roleTitle: "THEM".localized(),
+					locale: targetLocale,
+					text: translatedText,
+					placeholder: "Translated message will appear here".localized(),
+					accent: .duoThemAccentDeep,
+					textColor: .duoTableThemText,
+					backgroundColors: [.duoTableThemBackground, .duoTableThemBackgroundDeep],
+					isUpsideDown: true
+				)
+				.frame(height: proxy.size.height / 2)
+
+				DuoTableModePanel(
+					roleTitle: "YOU".localized(),
+					locale: sourceLocale,
+					text: sourceText,
+					placeholder: "Please input your message".localized(),
+					accent: .duoYouAccentDeep,
+					textColor: .duoTableYouText,
+					backgroundColors: [.duoTableYouBackground, .duoTableYouBackgroundDeep],
+					isUpsideDown: false,
+					onExit: onExit,
+					onSpeakToReply: onSpeakToReply
+				)
+				.frame(height: proxy.size.height / 2)
+			}
+			.overlay(alignment: .center) {
+				Image(systemName: "arrow.up.arrow.down")
+					.font(.system(size: 26, weight: .medium))
+					.foregroundStyle(Color.duoTextMuted)
+					.frame(width: 92, height: 92)
+					.background(Color.duoSurface, in: Circle())
+					.shadow(color: .black.opacity(0.14), radius: 28, x: 0, y: 12)
+					.accessibilityHidden(true)
+			}
+		}
+		.ignoresSafeArea()
+		.background(Color.duoBackground)
+		.statusBarHidden(true)
+		.accessibilityElement(children: .contain)
+	}
+}
+
+private struct DuoTableModePanel: View {
+	let roleTitle: String
+	let locale: TranslationLocale
+	let text: String
+	let placeholder: String
+	let accent: Color
+	let textColor: Color
+	let backgroundColors: [Color]
+	let isUpsideDown: Bool
+	var onExit: (() -> Void)?
+	var onSpeakToReply: (() -> Void)?
+
+	private var displayText: String {
+		text.isEmpty ? placeholder : text
+	}
+
+	var body: some View {
+		ZStack(alignment: .topTrailing) {
+			LinearGradient(
+				colors: backgroundColors,
+				startPoint: .topLeading,
+				endPoint: .bottomTrailing
+			)
+
+			VStack(spacing: 22) {
+				Spacer(minLength: 42)
+
+				DuoTableModeLanguagePill(
+					roleTitle: roleTitle,
+					locale: locale,
+					accent: accent
+				)
+
+				Text(displayText)
+					.font(.system(size: isUpsideDown ? 42 : 34, weight: .bold, design: .rounded))
+					.foregroundStyle(textColor)
+					.multilineTextAlignment(.center)
+					.lineSpacing(4)
+					.minimumScaleFactor(0.45)
+					.lineLimit(4)
+					.padding(.horizontal, 30)
+
+				if let onSpeakToReply {
+					Button(action: onSpeakToReply) {
+						Label("Speak to reply".localized(), systemImage: "microphone.fill")
+							.font(.system(size: 23, weight: .bold, design: .rounded))
+							.foregroundStyle(accent)
+							.padding(.horizontal, 28)
+							.frame(minHeight: 72)
+							.background(Color.duoSurface, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+							.shadow(color: .black.opacity(0.08), radius: 16, x: 0, y: 8)
+					}
+					.buttonStyle(.plain)
+				}
+
+				Spacer(minLength: isUpsideDown ? 82 : 62)
+			}
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+
+			if let onExit {
+				Button(action: onExit) {
+					Label("Exit".localized(), systemImage: "xmark")
+						.font(.system(size: 19, weight: .bold, design: .rounded))
+						.foregroundStyle(textColor)
+						.padding(.horizontal, 20)
+						.frame(minHeight: 58)
+						.background(Color.duoSurface, in: Capsule())
+						.shadow(color: .black.opacity(0.08), radius: 14, x: 0, y: 8)
+				}
+				.buttonStyle(.plain)
+				.padding(.top, 32)
+				.padding(.trailing, 34)
+			}
+		}
+		.rotationEffect(.degrees(isUpsideDown ? 180 : 0))
+	}
+}
+
+private struct DuoTableModeLanguagePill: View {
+	let roleTitle: String
+	let locale: TranslationLocale
+	let accent: Color
+
+	var body: some View {
+		HStack(spacing: 8) {
+			Text(locale.flagEmoji)
+				.font(.system(size: 18))
+
+			Text("\(roleTitle) · \(locale.displayName.uppercased())")
+				.font(.system(size: 19, weight: .bold, design: .rounded))
+				.foregroundStyle(accent)
+				.tracking(1.6)
+		}
+		.padding(.horizontal, 24)
+		.frame(minHeight: 54)
+		.background(Color.duoSurface, in: Capsule())
+		.shadow(color: .black.opacity(0.08), radius: 14, x: 0, y: 8)
+		.accessibilityElement(children: .combine)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Replace the old fullscreen/output-only path with the Duo Table Mode split hero\n- Add dedicated table-mode color tokens for THEM/YOU panels\n- Remove ads from Table Mode and add Exit + Speak to reply actions\n- Hide status UI for the table-mode presentation\n\n## Verification\n- mise x -- tuist build\n- mise x -- tuist test\n- git diff --check\n- Simulator screenshot: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-hero-status-hidden.png\n\n## Flow\n\n```mermaid\nflowchart TD\n    A[Main translation screen] --> B[Tap Table Mode]\n    B --> C[Split table hero: THEM top, YOU bottom]\n    C --> D{User action}\n    D -->|Exit| A\n    D -->|Speak to reply| E[Speech recognition]\n    E --> C\n```