### PR TITLE
Polish Table Mode design details

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -60,7 +60,7 @@ let project = Project(
                     ],
                     "NSMicrophoneUsageDescription": "For Speech Recognition",
                     "NSSpeechRecognitionUsageDescription": "For Speech Recognition",
-                    "UIViewControllerBasedStatusBarAppearance": false,
+					"UIViewControllerBasedStatusBarAppearance": true,
                     "SKAdNetworkItems": .array(skAdNetworks),
                 ]
             ),

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -301,8 +301,11 @@ private struct DuoTableModeView: View {
 				.frame(height: proxy.size.height / 2)
 			}
 			.overlay(alignment: .center) {
-				Image(systemName: "arrow.up.arrow.down")
-					.font(.system(size: 26, weight: .medium))
+				HStack(spacing: -3) {
+					Text("↑")
+					Text("↓")
+				}
+					.font(.system(size: 30, weight: .medium, design: .rounded))
 					.foregroundStyle(Color.duoTextMuted)
 					.frame(width: 92, height: 92)
 					.background(Color.duoSurface, in: Circle())
@@ -361,7 +364,7 @@ private struct DuoTableModePanel: View {
 
 				if let onSpeakToReply {
 					Button(action: onSpeakToReply) {
-						Label("Speak to reply".localized(), systemImage: "microphone.fill")
+						Text("🎤 \("Speak to reply".localized())")
 							.font(.system(size: 23, weight: .bold, design: .rounded))
 							.foregroundStyle(accent)
 							.padding(.horizontal, 28)
@@ -378,7 +381,7 @@ private struct DuoTableModePanel: View {
 
 			if let onExit {
 				Button(action: onExit) {
-					Label("Exit".localized(), systemImage: "xmark")
+					Text("× \("Exit".localized())")
 						.font(.system(size: 19, weight: .bold, design: .rounded))
 						.foregroundStyle(textColor)
 						.padding(.horizontal, 20)


### PR DESCRIPTION
## Summary\n- Match Table Mode control glyphs to the design prototype\n- Use text arrows for the center orb to avoid emoji-style rendering\n- Use prototype-style × Exit and 🎤 Speak to reply labels\n- Enable view-controller-based status bar appearance so Table Mode can hide the status bar\n\n## Verification\n- mise x -- tuist build\n- mise x -- tuist test\n- git diff --check\n- Simulator screenshot: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-polish-final.png\n\n## Flow\n\n```mermaid\nflowchart TD\n    A[Main translation screen] --> B[Tap Table Mode]\n    B --> C[Status bar hidden split Table Mode]\n    C --> D[Prototype-style center arrows and action buttons]\n    D --> E{Action}\n    E -->|× Exit| A\n    E -->|🎤 Speak to reply| F[Speech recognition]\n```