### PR TITLE
Guard empty Table Mode

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -24,6 +24,11 @@ struct TranslationScreen: View {
 
 	private let topContentPadding: CGFloat = 12
 
+	private var canEnterTableMode: Bool {
+		!viewModel.nativeText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+		!viewModel.translatedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+	}
+
 	init() {
 		// TranslationSession will be created dynamically in TranslationViewModel
 		// when translate button is pressed
@@ -166,21 +171,24 @@ struct TranslationScreen: View {
 						.disabled(!viewModel.canTranslate)
 
 						Button(action: {
+							guard canEnterTableMode else { return }
 							viewModel.toggleFullScreen()
 						}) {
 							Image(systemName: "person.line.dotted.person.fill")
 								.font(.system(size: 18, weight: .semibold))
 								.frame(width: 52, height: 52)
-								.background(Color.duoThemAccent.opacity(0.14))
-								.foregroundStyle(Color.duoThemAccentDeep)
+								.background(Color.duoThemAccent.opacity(canEnterTableMode ? 0.14 : 0.08))
+								.foregroundStyle(canEnterTableMode ? Color.duoThemAccentDeep : Color.duoTextMuted)
 								.clipShape(.rect(cornerRadius: 16, style: .continuous))
 								.overlay(
 									RoundedRectangle(cornerRadius: 16, style: .continuous)
-										.stroke(Color.duoThemAccent.opacity(0.24), lineWidth: 1)
+										.stroke(Color.duoThemAccent.opacity(canEnterTableMode ? 0.24 : 0.10), lineWidth: 1)
 								)
 						}
+						.disabled(!canEnterTableMode)
 						.buttonStyle(.plain)
 						.accessibilityLabel("Table Mode")
+						.accessibilityHint(canEnterTableMode ? "" : "Translate or enter text before using Table Mode".localized())
 					}
 					.padding(.horizontal, 16)
 					.padding(.bottom, 8)


### PR DESCRIPTION
## Summary\n- Disable Table Mode until there is source or translated text\n- Prevent the Table Mode hero from showing oversized placeholder content\n- Add a VoiceOver hint explaining when Table Mode becomes available\n\n## Verification\n- mise x -- tuist build\n- mise x -- tuist test\n- git diff --check\n- Simulator screenshot: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-empty-guard.png\n\n## Flow\n\n```mermaid\nflowchart TD\n    A[Empty main screen] --> B[Table Mode button disabled]\n    C[User enters/translates text] --> D[Table Mode button enabled]\n    D --> E[Open Duo Table Mode hero with actual conversation text]\n```