### PR TITLE
Reduce Table Mode center orb size

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -305,11 +305,11 @@ private struct DuoTableModeView: View {
 					Text("↑")
 					Text("↓")
 				}
-					.font(.system(size: 30, weight: .medium, design: .rounded))
+					.font(.system(size: 22, weight: .medium, design: .rounded))
 					.foregroundStyle(Color.duoTextMuted)
-					.frame(width: 92, height: 92)
+					.frame(width: 64, height: 64)
 					.background(Color.duoSurface, in: Circle())
-					.shadow(color: .black.opacity(0.14), radius: 28, x: 0, y: 12)
+					.shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 8)
 					.accessibilityHidden(true)
 			}
 		}


### PR DESCRIPTION
## Summary\n- Reduce the Table Mode center orb from 92pt to 64pt\n- Scale down the center arrows from 30pt to 22pt\n- Soften the orb shadow to better match the design reference\n\n## Verification\n- mise x -- tuist build\n- mise x -- tuist test\n- git diff --check\n- Simulator screenshot: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-center-orb-small.png\n\n## Flow\n\n```mermaid\nflowchart TD\n    A[Open Table Mode] --> B[Split THEM/YOU panels]\n    B --> C[Smaller center arrow orb at panel boundary]\n```