### PR TITLE
Reduce Table Mode button height

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -365,14 +365,17 @@ private struct DuoTableModePanel: View {
 				if let onSpeakToReply {
 					Button(action: onSpeakToReply) {
 						Text("🎤 \("Speak to reply".localized())")
-							.font(.system(size: 23, weight: .bold, design: .rounded))
+							.font(.system(size: 20, weight: .bold, design: .rounded))
 							.foregroundStyle(accent)
-							.padding(.horizontal, 28)
-							.frame(minHeight: 72)
-							.background(Color.duoSurface, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+							.padding(.horizontal, 24)
+							.frame(minHeight: 52)
+							.background(Color.duoSurface, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
 							.shadow(color: .black.opacity(0.08), radius: 16, x: 0, y: 8)
 					}
 					.buttonStyle(.plain)
+					.padding(.vertical, 10)
+					.contentShape(Rectangle())
+					.accessibilityLabel("Speak to reply".localized())
 				}
 
 				Spacer(minLength: isUpsideDown ? 82 : 62)
@@ -382,14 +385,18 @@ private struct DuoTableModePanel: View {
 			if let onExit {
 				Button(action: onExit) {
 					Text("× \("Exit".localized())")
-						.font(.system(size: 19, weight: .bold, design: .rounded))
+						.font(.system(size: 16, weight: .bold, design: .rounded))
 						.foregroundStyle(textColor)
-						.padding(.horizontal, 20)
-						.frame(minHeight: 58)
+						.padding(.horizontal, 16)
+						.frame(minHeight: 44)
 						.background(Color.duoSurface, in: Capsule())
 						.shadow(color: .black.opacity(0.08), radius: 14, x: 0, y: 8)
 				}
 				.buttonStyle(.plain)
+				.padding(.vertical, 7)
+				.padding(.horizontal, 4)
+				.contentShape(Rectangle())
+				.accessibilityLabel("Exit".localized())
 				.padding(.top, 32)
 				.padding(.trailing, 34)
 			}


### PR DESCRIPTION
## Summary\n- Reduce visible Table Mode button heights to better match the design reference\n- Keep larger invisible touch areas with outer padding/content shapes\n- Add explicit accessibility labels for the compact controls\n\n## Verification\n- mise x -- tuist build\n- mise x -- tuist test\n- git diff --check\n- Simulator screenshot: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-button-height.png\n\n## Flow\n\n```mermaid\nflowchart TD\n    A[Open Table Mode] --> B[Tap compact Exit or Speak button]\n    B --> C[Invisible padding preserves comfortable touch target]\n```