### PR TITLE
Fix language picker swap button

### DIFF
--- a/Projects/App/Sources/Screens/LanguageSelectionScreen.swift
+++ b/Projects/App/Sources/Screens/LanguageSelectionScreen.swift
@@ -43,6 +43,7 @@ struct LanguageSelectionScreen: View {
 	let sourceLocale: TranslationLocale?
 	let targetLocale: TranslationLocale?
 	let onSelect: (TranslationLocale) -> Void
+	let onSwap: (() -> Void)?
 
 	@Environment(\.dismiss) private var dismiss
 	@State private var searchText = ""
@@ -53,7 +54,8 @@ struct LanguageSelectionScreen: View {
 		selectedRole: LanguageSelectionRole = .target,
 		sourceLocale: TranslationLocale? = nil,
 		targetLocale: TranslationLocale? = nil,
-		onSelect: @escaping (TranslationLocale) -> Void
+		onSelect: @escaping (TranslationLocale) -> Void,
+		onSwap: (() -> Void)? = nil
 	) {
 		self.languages = languages
 		self.selectedLocale = selectedLocale
@@ -61,6 +63,7 @@ struct LanguageSelectionScreen: View {
 		self.sourceLocale = sourceLocale
 		self.targetLocale = targetLocale
 		self.onSelect = onSelect
+		self.onSwap = onSwap
 	}
 
 	private var currentSourceLocale: TranslationLocale {
@@ -152,12 +155,19 @@ private extension LanguageSelectionScreen {
 				accent: .duoYouAccent
 			)
 
-			Image(systemName: "arrow.left.arrow.right")
-				.font(.system(size: 18, weight: .medium))
-				.foregroundStyle(Color.duoTextMuted)
-				.frame(width: 58, height: 58)
-				.background(Color.duoControlSurface.opacity(0.72), in: Circle())
-				.accessibilityHidden(true)
+			Button {
+				onSwap?()
+				dismiss()
+			} label: {
+				Image(systemName: "arrow.left.arrow.right")
+					.font(.system(size: 18, weight: .medium))
+					.foregroundStyle(Color.duoTextMuted)
+					.frame(width: 58, height: 58)
+					.background(Color.duoControlSurface.opacity(0.72), in: Circle())
+			}
+			.buttonStyle(.plain)
+			.disabled(onSwap == nil)
+			.accessibilityLabel("Swap languages".localized())
 
 			LanguageSummaryColumn(
 				title: "THEM".localized(),

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -89,6 +89,9 @@ struct TranslationScreen: View {
 							onLocaleChange: { locale in
 								viewModel.updateTranslatedLocale(locale)
 							},
+							onSwap: {
+								viewModel.swapLanguages()
+							},
 							isFullScreen: false,
 							onToggleFullScreen: { },
 							deviceOrientation: viewModel.deviceOrientation

--- a/Projects/App/Sources/Views/TranslationInputView.swift
+++ b/Projects/App/Sources/Views/TranslationInputView.swift
@@ -42,8 +42,6 @@ struct TranslationInputView: View {
 
 				Spacer()
 
-				DuoLanguageSwapButton(action: onSwap)
-
 				Text(counterText)
 					.font(.system(size: 12))
 					.foregroundStyle(Color.duoTextMuted)
@@ -55,7 +53,8 @@ struct TranslationInputView: View {
 					selectedRole: .source,
 					sourceLocale: locale,
 					targetLocale: targetLocale,
-					onSelect: onLocaleChange
+					onSelect: onLocaleChange,
+					onSwap: onSwap
 				)
 				.presentationDetents([.medium, .large])
 			}
@@ -99,24 +98,6 @@ struct TranslationInputView: View {
 				.stroke(Color.duoYouAccent.opacity(0.22), lineWidth: 1)
 		)
 		.clipShape(.rect(cornerRadius: 20, style: .continuous))
-	}
-}
-
-private struct DuoLanguageSwapButton: View {
-	let action: () -> Void
-
-	var body: some View {
-		Button(action: action) {
-			Image(systemName: "arrow.up.arrow.down")
-				.font(.system(size: 14, weight: .bold, design: .rounded))
-				.foregroundStyle(Color.duoTextMuted)
-				.frame(width: 32, height: 32)
-				.background(Color.duoControlSurface, in: Circle())
-		}
-		.buttonStyle(.plain)
-		.frame(width: 44, height: 44)
-		.contentShape(Circle())
-		.accessibilityLabel("Swap languages".localized())
 	}
 }
 

--- a/Projects/App/Sources/Views/TranslationInputView.swift
+++ b/Projects/App/Sources/Views/TranslationInputView.swift
@@ -42,6 +42,8 @@ struct TranslationInputView: View {
 
 				Spacer()
 
+				DuoLanguageSwapButton(action: onSwap)
+
 				Text(counterText)
 					.font(.system(size: 12))
 					.foregroundStyle(Color.duoTextMuted)
@@ -97,6 +99,24 @@ struct TranslationInputView: View {
 				.stroke(Color.duoYouAccent.opacity(0.22), lineWidth: 1)
 		)
 		.clipShape(.rect(cornerRadius: 20, style: .continuous))
+	}
+}
+
+private struct DuoLanguageSwapButton: View {
+	let action: () -> Void
+
+	var body: some View {
+		Button(action: action) {
+			Image(systemName: "arrow.up.arrow.down")
+				.font(.system(size: 14, weight: .bold, design: .rounded))
+				.foregroundStyle(Color.duoTextMuted)
+				.frame(width: 32, height: 32)
+				.background(Color.duoControlSurface, in: Circle())
+		}
+		.buttonStyle(.plain)
+		.frame(width: 44, height: 44)
+		.contentShape(Circle())
+		.accessibilityLabel("Swap languages".localized())
 	}
 }
 

--- a/Projects/App/Sources/Views/TranslationOutputView.swift
+++ b/Projects/App/Sources/Views/TranslationOutputView.swift
@@ -15,6 +15,7 @@ struct TranslationOutputView: View {
 	let availableLocales: [TranslationLocale]
 	let placeholder: String
 	let onLocaleChange: (TranslationLocale) -> Void
+	let onSwap: () -> Void
 	let isFullScreen: Bool
 	let onToggleFullScreen: () -> Void
 	let deviceOrientation: UIDeviceOrientation
@@ -86,7 +87,8 @@ struct TranslationOutputView: View {
 					selectedRole: .target,
 					sourceLocale: sourceLocale,
 					targetLocale: locale,
-					onSelect: onLocaleChange
+					onSelect: onLocaleChange,
+					onSwap: onSwap
 				)
 				.presentationDetents([.medium, .large])
 			}
@@ -243,6 +245,7 @@ private struct FontSizeSheetView: View {
 				availableLocales: TranslationLocale.allCases,
 				placeholder: "Translated message will appear here",
 				onLocaleChange: { _ in },
+				onSwap: { },
 				isFullScreen: isFullScreen,
 				onToggleFullScreen: {
 					isFullScreen.toggle()

--- a/Projects/App/Tests/TalktransTests.swift
+++ b/Projects/App/Tests/TalktransTests.swift
@@ -98,4 +98,19 @@ struct TalktransTests {
 		#expect(!viewModel.isValidSessionBindingRequestID(nil))
 	}
 
+	@Test @MainActor func translationViewModel_swapLanguages_exchangesLocalesAndText() {
+		let viewModel = TranslationViewModel()
+		viewModel.nativeLocale = .english
+		viewModel.translatedLocale = .korean
+		viewModel.nativeText = "Hello"
+		viewModel.translatedText = "안녕하세요"
+
+		viewModel.swapLanguages()
+
+		#expect(viewModel.nativeLocale == .korean)
+		#expect(viewModel.translatedLocale == .english)
+		#expect(viewModel.nativeText == "안녕하세요")
+		#expect(viewModel.translatedText == "Hello")
+	}
+
 }


### PR DESCRIPTION
## Summary
- Fix the existing `<->` button in the language picker sheet by making it a real button
- Wire the picker swap action to `TranslationViewModel.swapLanguages()` from both source and target language sheets
- Dismiss the picker after swapping so the updated main screen is visible
- Add a ViewModel regression test for swapping locales and text

## Verification
- mise x -- tuist build
- mise x -- tuist test
- git diff --check
- Opened language picker sheet: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/language-picker-sheet-open-points.png
- After tapping the sheet `<->` button: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/language-picker-swap-after-center.png

## Flow

```mermaid
flowchart TD
    A[Open language picker sheet] --> B[Tap existing <-> button]
    B --> C[LanguageSelectionScreen calls onSwap]
    C --> D[TranslationViewModel swaps source/target locales and text]
    D --> E[Sheet dismisses and main screen shows swapped languages]
```