### PR TITLE
Allow long Speak Mode text to scroll

### DIFF
--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -40,7 +40,7 @@ struct SpeechRecognitionScreen: View {
 				microphoneButton
 
 				recognizedText
-					.padding(.top, 76)
+					.padding(.top, hasLongDisplayText ? 44 : 76)
 
 				if shouldShowErrorMessage, let errorMessage = viewModel.errorMessage {
 					errorMessageView(errorMessage)
@@ -125,14 +125,19 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private var recognizedText: some View {
-		Text(displayText)
-			.font(.system(size: 30, weight: .bold))
-			.foregroundStyle(text.isEmpty ? Color.duoTextMuted : Color.duoTextPrimary)
-			.multilineTextAlignment(.center)
-			.lineSpacing(8)
-			.frame(maxWidth: .infinity)
-			.padding(.horizontal, 56)
-			.accessibilityLabel(text.isEmpty ? "No recognized text yet" : "Recognized text: \(text)")
+		ScrollView(.vertical) {
+			Text(displayText)
+				.font(.system(size: hasLongDisplayText ? 24 : 30, weight: .bold))
+				.foregroundStyle(text.isEmpty ? Color.duoTextMuted : Color.duoTextPrimary)
+				.multilineTextAlignment(.center)
+				.lineSpacing(hasLongDisplayText ? 6 : 8)
+				.fixedSize(horizontal: false, vertical: true)
+				.frame(maxWidth: .infinity)
+				.padding(.horizontal, 56)
+		}
+		.frame(maxHeight: hasLongDisplayText ? 220 : 150)
+		.scrollBounceBehavior(.basedOnSize)
+		.accessibilityLabel(text.isEmpty ? "No recognized text yet" : "Recognized text: \(text)")
 	}
 
 	private var actionButtons: some View {
@@ -191,6 +196,10 @@ struct SpeechRecognitionScreen: View {
 		}
 
 		return "Listening…"
+	}
+
+	private var hasLongDisplayText: Bool {
+		displayText.count > 80 || displayText.components(separatedBy: .newlines).count > 3
 	}
 
 	private func errorMessageView(_ message: String) -> some View {


### PR DESCRIPTION
## Summary
- Fix Speak Mode transcript/input truncation when recognized speech wraps beyond ~3 lines.
- Replace the fixed plain text area with a bounded vertical `ScrollView`.
- Use slightly smaller text, tighter line spacing, and reduced top spacing only for longer transcripts.
- Preserve the existing centered large-text style for short transcripts and `Listening…`.

## User flow
```mermaid
flowchart TD
  A[User opens Speak Mode] --> B[Speech recognition updates transcript]
  B --> C{Transcript is long?}
  C -- No --> D[Show original large centered text]
  C -- Yes --> E[Show bounded scrollable transcript]
  E --> F[User scrolls to read full input]
```

## Verification
- `mise x -- tuist build` ✅
- `mise x -- tuist test` ✅
- `git diff --check` ✅
- GitHub Actions Build & Test ✅

## Risk / rollback
- Low-risk SwiftUI layout-only change in `SpeechRecognitionScreen`.
- Rollback: revert this PR if Speak Mode spacing needs further tuning.

## Result
<img width="362" height="277" alt="Speak Mode long transcript preview" src="https://github.com/user-attachments/assets/3199d44f-f8f4-46c5-86ff-74c98775526b" />