### PR TITLE
Drive Speak Mode controls from transcript overflow

### DIFF
--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -222,42 +222,19 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private var transcriptCard: some View {
-		VStack(alignment: .leading, spacing: 12) {
-			HStack(spacing: 8) {
-				Text(verbatim: "Transcript")
-					.font(.system(size: 13, weight: .bold))
-					.foregroundStyle(Color.duoTextSecondary)
-
-				Spacer()
-
-				Image(systemName: "chevron.up.chevron.down")
-					.font(.system(size: 11, weight: .bold))
-					.foregroundStyle(Color.duoTextMuted)
-			}
-
-			ScrollView(.vertical) {
-				Text(displayText)
-					.font(.system(size: shouldUseTranscriptFirstMode ? 23 : 24, weight: .bold))
-					.foregroundStyle(Color.duoTextPrimary)
-					.multilineTextAlignment(.leading)
-					.lineSpacing(6)
-					.fixedSize(horizontal: false, vertical: true)
-					.frame(maxWidth: .infinity, alignment: .leading)
-					.padding(.bottom, 6)
-			}
-			.frame(maxHeight: transcriptMaxHeight)
-			.scrollBounceBehavior(.basedOnSize)
+		ScrollView(.vertical) {
+			Text(displayText)
+				.font(.system(size: shouldUseTranscriptFirstMode ? 23 : 24, weight: .bold))
+				.foregroundStyle(Color.duoTextPrimary)
+				.multilineTextAlignment(.center)
+				.lineSpacing(6)
+				.fixedSize(horizontal: false, vertical: true)
+				.frame(maxWidth: .infinity)
+				.padding(.bottom, 6)
 		}
-		.padding(.horizontal, 20)
-		.padding(.vertical, 16)
-		.frame(maxWidth: .infinity)
-		.background(Color.duoControlSurface.opacity(0.72))
-		.overlay(
-			RoundedRectangle(cornerRadius: 24, style: .continuous)
-				.stroke(Color.duoYouAccent.opacity(0.18), lineWidth: 1)
-		)
-		.clipShape(.rect(cornerRadius: 24, style: .continuous))
-		.padding(.horizontal, 32)
+		.frame(maxHeight: transcriptMaxHeight)
+		.scrollBounceBehavior(.basedOnSize)
+		.padding(.horizontal, 56)
 	}
 
 	private var actionButtons: some View {

--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -16,6 +16,7 @@ struct SpeechRecognitionScreen: View {
 	var onCancel: (() -> Void)?
 	@State private var transcriptContentHeight: CGFloat = 0
 	@State private var isListeningStatusPulsing = false
+	@State private var recognitionPrefixText = ""
 
 	var body: some View {
 		ZStack {
@@ -65,7 +66,7 @@ struct SpeechRecognitionScreen: View {
 		}
 		.onChange(of: viewModel.recognizedText) { _, newValue in
 			if !newValue.isEmpty {
-				text = newValue
+				text = combinedRecognitionText(newSegment: newValue)
 			}
 		}
 		.onAppear {
@@ -137,7 +138,7 @@ struct SpeechRecognitionScreen: View {
 					.frame(width: 7, height: 7)
 					.opacity(viewModel.isRecognizing ? 1 : 0.45)
 
-				Text(verbatim: viewModel.isRecognizing ? "Stop" : "Resume")
+				Text(verbatim: viewModel.isRecognizing ? "Stop" : "Continue")
 					.font(.system(size: 13, weight: .bold))
 					.foregroundStyle(Color.duoYouAccentDeep)
 			}
@@ -151,7 +152,7 @@ struct SpeechRecognitionScreen: View {
 			.contentShape(.capsule)
 		}
 		.buttonStyle(.plain)
-		.accessibilityLabel(viewModel.isRecognizing ? "Stop listening" : "Resume listening")
+		.accessibilityLabel(viewModel.isRecognizing ? "Stop listening" : "Continue speaking")
 	}
 
 	private var microphoneButton: some View {
@@ -380,9 +381,22 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private func startRecognition() {
+		recognitionPrefixText = text.trimmingCharacters(in: .whitespacesAndNewlines)
 		viewModel.startRecognition(locale: sourceLocale.locale) { _ in
 			// Text is mirrored through recognizedText onChange.
 		}
+	}
+
+	private func combinedRecognitionText(newSegment: String) -> String {
+		let trimmedSegment = newSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !recognitionPrefixText.isEmpty else { return trimmedSegment }
+		guard !trimmedSegment.isEmpty else { return recognitionPrefixText }
+
+		if recognitionPrefixText.last?.isWhitespace == true {
+			return recognitionPrefixText + trimmedSegment
+		}
+
+		return recognitionPrefixText + " " + trimmedSegment
 	}
 
 	#if targetEnvironment(simulator)

--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -15,7 +15,6 @@ struct SpeechRecognitionScreen: View {
 	var onProcess: (() -> Void)?
 	var onCancel: (() -> Void)?
 	@State private var transcriptContentHeight: CGFloat = 0
-	@State private var transcriptViewportHeight: CGFloat = 0
 	@State private var isListeningStatusPulsing = false
 
 	var body: some View {
@@ -60,6 +59,9 @@ struct SpeechRecognitionScreen: View {
 					.padding(.bottom, 64)
 			}
 			.frame(maxWidth: .infinity, maxHeight: .infinity)
+			.overlay(alignment: .topLeading) {
+				transcriptOverflowMeasurement
+			}
 		}
 		.onChange(of: viewModel.recognizedText) { _, newValue in
 			if !newValue.isEmpty {
@@ -203,7 +205,7 @@ struct SpeechRecognitionScreen: View {
 
 	private var recognizedText: some View {
 		Group {
-			if hasLongDisplayText {
+			if hasLongDisplayText || shouldUseTranscriptFirstMode {
 				transcriptCard
 			} else {
 				Text(displayText)
@@ -242,27 +244,9 @@ struct SpeechRecognitionScreen: View {
 					.fixedSize(horizontal: false, vertical: true)
 					.frame(maxWidth: .infinity, alignment: .leading)
 					.padding(.bottom, 6)
-					.background(
-						GeometryReader { proxy in
-							Color.clear.preference(key: TranscriptContentHeightKey.self, value: proxy.size.height)
-						}
-					)
 			}
 			.frame(maxHeight: transcriptMaxHeight)
-			.background(
-				GeometryReader { proxy in
-					Color.clear.preference(key: TranscriptViewportHeightKey.self, value: proxy.size.height)
-				}
-			)
 			.scrollBounceBehavior(.basedOnSize)
-		}
-		.onPreferenceChange(TranscriptContentHeightKey.self) { height in
-			transcriptContentHeight = height
-		}
-		.onPreferenceChange(TranscriptViewportHeightKey.self) { height in
-			if !shouldUseTranscriptFirstMode {
-				transcriptViewportHeight = height
-			}
 		}
 		.padding(.horizontal, 20)
 		.padding(.vertical, 16)
@@ -313,6 +297,29 @@ struct SpeechRecognitionScreen: View {
 		}
 	}
 
+	private var transcriptOverflowMeasurement: some View {
+		GeometryReader { proxy in
+			Text(displayText)
+				.font(.system(size: 24, weight: .bold))
+				.lineSpacing(6)
+				.fixedSize(horizontal: false, vertical: true)
+				.frame(width: max(1, proxy.size.width - transcriptMeasurementHorizontalInset), alignment: .leading)
+				.opacity(0)
+				.accessibilityHidden(true)
+				.background(
+					GeometryReader { textProxy in
+						Color.clear.preference(key: TranscriptContentHeightKey.self, value: textProxy.size.height)
+					}
+				)
+		}
+		.allowsHitTesting(false)
+		.frame(height: 0)
+		.clipped()
+		.onPreferenceChange(TranscriptContentHeightKey.self) { height in
+			transcriptContentHeight = height
+		}
+	}
+
 	private var shouldShowErrorMessage: Bool {
 		#if targetEnvironment(simulator)
 		return false
@@ -343,11 +350,7 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private var transcriptNeedsScrolling: Bool {
-		hasLongDisplayText && transcriptContentHeight > measuredCompactTranscriptHeight + 1
-	}
-
-	private var measuredCompactTranscriptHeight: CGFloat {
-		transcriptViewportHeight > 0 ? transcriptViewportHeight : compactTranscriptMaxHeight
+		transcriptContentHeight > compactTranscriptMaxHeight + 1
 	}
 
 	private var transcriptMaxHeight: CGFloat {
@@ -360,6 +363,10 @@ struct SpeechRecognitionScreen: View {
 
 	private var expandedTranscriptMaxHeight: CGFloat {
 		360
+	}
+
+	private var transcriptMeasurementHorizontalInset: CGFloat {
+		104
 	}
 
 	private var listeningStatusScale: CGFloat {
@@ -403,7 +410,8 @@ struct SpeechRecognitionScreen: View {
 
 	#if targetEnvironment(simulator)
 	private func applySimulatorScreenshotMock() {
-		let mockText = "가장 가까운 지하철역이\n어디예요?"
+		let existingText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+		let mockText = existingText.isEmpty ? "가장 가까운 지하철역이\n어디예요?" : existingText
 		viewModel.stopRecognition()
 		viewModel.errorMessage = nil
 		viewModel.recognizedText = mockText
@@ -420,14 +428,6 @@ struct SpeechRecognitionScreen: View {
 }
 
 private struct TranscriptContentHeightKey: PreferenceKey {
-	static var defaultValue: CGFloat = 0
-
-	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-		value = max(value, nextValue())
-	}
-}
-
-private struct TranscriptViewportHeightKey: PreferenceKey {
 	static var defaultValue: CGFloat = 0
 
 	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -15,6 +15,7 @@ struct SpeechRecognitionScreen: View {
 	var onProcess: (() -> Void)?
 	var onCancel: (() -> Void)?
 	@State private var transcriptContentHeight: CGFloat = 0
+	@State private var transcriptViewportHeight: CGFloat = 0
 	@State private var isListeningStatusPulsing = false
 
 	var body: some View {
@@ -248,10 +249,20 @@ struct SpeechRecognitionScreen: View {
 					)
 			}
 			.frame(maxHeight: transcriptMaxHeight)
+			.background(
+				GeometryReader { proxy in
+					Color.clear.preference(key: TranscriptViewportHeightKey.self, value: proxy.size.height)
+				}
+			)
 			.scrollBounceBehavior(.basedOnSize)
 		}
 		.onPreferenceChange(TranscriptContentHeightKey.self) { height in
 			transcriptContentHeight = height
+		}
+		.onPreferenceChange(TranscriptViewportHeightKey.self) { height in
+			if !shouldUseTranscriptFirstMode {
+				transcriptViewportHeight = height
+			}
 		}
 		.padding(.horizontal, 20)
 		.padding(.vertical, 16)
@@ -332,7 +343,11 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private var transcriptNeedsScrolling: Bool {
-		hasLongDisplayText && transcriptContentHeight > compactTranscriptMaxHeight + 1
+		hasLongDisplayText && transcriptContentHeight > measuredCompactTranscriptHeight + 1
+	}
+
+	private var measuredCompactTranscriptHeight: CGFloat {
+		transcriptViewportHeight > 0 ? transcriptViewportHeight : compactTranscriptMaxHeight
 	}
 
 	private var transcriptMaxHeight: CGFloat {
@@ -405,6 +420,14 @@ struct SpeechRecognitionScreen: View {
 }
 
 private struct TranscriptContentHeightKey: PreferenceKey {
+	static var defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		value = max(value, nextValue())
+	}
+}
+
+private struct TranscriptViewportHeightKey: PreferenceKey {
 	static var defaultValue: CGFloat = 0
 
 	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -14,6 +14,8 @@ struct SpeechRecognitionScreen: View {
 	var processTitle: String?
 	var onProcess: (() -> Void)?
 	var onCancel: (() -> Void)?
+	@State private var transcriptContentHeight: CGFloat = 0
+	@State private var isListeningStatusPulsing = false
 
 	var body: some View {
 		ZStack {
@@ -64,6 +66,7 @@ struct SpeechRecognitionScreen: View {
 			}
 		}
 		.onAppear {
+			isListeningStatusPulsing = true
 			viewModel.resetSessionState()
 			#if targetEnvironment(simulator)
 			applySimulatorScreenshotMock()
@@ -118,6 +121,9 @@ struct SpeechRecognitionScreen: View {
 				.font(.system(size: 13, weight: .bold))
 				.foregroundStyle(Color.duoYouAccentDeep.opacity(0.82))
 		}
+		.scaleEffect(listeningStatusScale)
+		.opacity(listeningStatusOpacity)
+		.animation(.easeInOut(duration: 0.85).repeatForever(autoreverses: true), value: isListeningStatusPulsing)
 	}
 
 	private var compactListeningControl: some View {
@@ -132,6 +138,9 @@ struct SpeechRecognitionScreen: View {
 					.font(.system(size: 13, weight: .bold))
 					.foregroundStyle(Color.duoYouAccentDeep)
 			}
+			.scaleEffect(listeningStatusScale)
+			.opacity(listeningStatusOpacity)
+			.animation(.easeInOut(duration: 0.85).repeatForever(autoreverses: true), value: isListeningStatusPulsing)
 			.padding(.horizontal, 12)
 			.padding(.vertical, 8)
 			.background(Color.duoYouAccent.opacity(0.13))
@@ -232,9 +241,17 @@ struct SpeechRecognitionScreen: View {
 					.fixedSize(horizontal: false, vertical: true)
 					.frame(maxWidth: .infinity, alignment: .leading)
 					.padding(.bottom, 6)
+					.background(
+						GeometryReader { proxy in
+							Color.clear.preference(key: TranscriptContentHeightKey.self, value: proxy.size.height)
+						}
+					)
 			}
-			.frame(maxHeight: shouldUseTranscriptFirstMode ? 360 : 218)
+			.frame(maxHeight: transcriptMaxHeight)
 			.scrollBounceBehavior(.basedOnSize)
+		}
+		.onPreferenceChange(TranscriptContentHeightKey.self) { height in
+			transcriptContentHeight = height
 		}
 		.padding(.horizontal, 20)
 		.padding(.vertical, 16)
@@ -307,17 +324,35 @@ struct SpeechRecognitionScreen: View {
 	}
 
 	private var hasLongDisplayText: Bool {
-		displayText.count > 80 || estimatedDisplayLineCount > 3
+		displayText.count > 80 || displayText.components(separatedBy: .newlines).count > 3
 	}
 
 	private var shouldUseTranscriptFirstMode: Bool {
-		estimatedDisplayLineCount > 6 || displayText.count > 150
+		transcriptNeedsScrolling
 	}
 
-	private var estimatedDisplayLineCount: Int {
-		let explicitLines = displayText.components(separatedBy: .newlines).count
-		let estimatedWrappedLines = Int(ceil(Double(displayText.count) / 20.0))
-		return max(explicitLines, estimatedWrappedLines)
+	private var transcriptNeedsScrolling: Bool {
+		hasLongDisplayText && transcriptContentHeight > compactTranscriptMaxHeight + 1
+	}
+
+	private var transcriptMaxHeight: CGFloat {
+		shouldUseTranscriptFirstMode ? expandedTranscriptMaxHeight : compactTranscriptMaxHeight
+	}
+
+	private var compactTranscriptMaxHeight: CGFloat {
+		218
+	}
+
+	private var expandedTranscriptMaxHeight: CGFloat {
+		360
+	}
+
+	private var listeningStatusScale: CGFloat {
+		viewModel.isRecognizing && isListeningStatusPulsing ? 1.04 : 1
+	}
+
+	private var listeningStatusOpacity: Double {
+		viewModel.isRecognizing && isListeningStatusPulsing ? 0.72 : 1
 	}
 
 	private func errorMessageView(_ message: String) -> some View {
@@ -366,5 +401,13 @@ struct SpeechRecognitionScreen: View {
 	private func cancel() {
 		viewModel.stopRecognition()
 		onCancel?()
+	}
+}
+
+private struct TranscriptContentHeightKey: PreferenceKey {
+	static var defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		value = max(value, nextValue())
 	}
 }


### PR DESCRIPTION
## Summary
- Hide the large Speak Mode mic when the rendered transcript actually needs scrolling.
- Replace the previous hardcoded 6+ line transcript-first trigger with measured transcript content overflow.
- Add a subtle pulse animation to the top-right listening status / Stop-Resume control.

## User flow
```mermaid
flowchart TD
  A[Transcript text updates] --> B[Measure rendered transcript height]
  B --> C{Content exceeds compact scroll area?}
  C -- No --> D[Keep large/small mic layout]
  C -- Yes --> E[Hide large mic]
  E --> F[Show animated Stop/Resume in top pill]
  F --> G[Use larger scrollable transcript area]
```

## Verification
- `mise x -- tuist build` ✅
- `mise x -- tuist test` ✅
- `git diff --check` ✅

## Risk / rollback
- SwiftUI layout-only change scoped to `SpeechRecognitionScreen`.
- Rollback by reverting this PR if overflow threshold or animation needs tuning.

## Result
<img width="606" alt="Screenshot 2026-07-07 at 9 38 21 AM" src="https://github.com/user-attachments/assets/369e67c2-1ba5-436b-82da-e41ff130e17d" />
<img width="369" height="240" alt="스크린샷 2026-07-07 오전 9 48 33" src="https://github.com/user-attachments/assets/2ce0dfc0-bb02-49fa-8ac5-3109bac484aa" />

