### PR TITLE
Remove inactive settings button

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -68,8 +68,7 @@ struct TranslationScreen: View {
 				// Normal Mode - Show all UI elements
 				VStack(spacing: 8) {
 					DuoHeaderView(
-						onHistoryTapped: { showHistory = true },
-						onSettingsTapped: { }
+						onHistoryTapped: { showHistory = true }
 					)
 						.padding(.horizontal, 18)
 						.padding(.top, topContentPadding)
@@ -458,7 +457,6 @@ private struct DuoTableModeLanguagePill: View {
 
 private struct DuoHeaderView: View {
 	let onHistoryTapped: () -> Void
-	let onSettingsTapped: () -> Void
 
 	var body: some View {
 		HStack(spacing: 12) {
@@ -471,29 +469,16 @@ private struct DuoHeaderView: View {
 
 			Spacer()
 
-			HStack(spacing: 8) {
-				Button(action: onHistoryTapped) {
-					Image(systemName: "clock.arrow.circlepath")
-						.font(.system(size: 14, weight: .semibold))
-						.foregroundStyle(Color.duoThemAccent)
-						.frame(width: 32, height: 32)
-						.background(Color.duoSurface, in: Circle())
-				}
-				.accessibilityLabel("Translation history")
-
-				Button(action: onSettingsTapped) {
-					Image(systemName: "gearshape")
-						.font(.system(size: 14, weight: .semibold))
-						.foregroundStyle(Color.duoYouAccent)
-						.frame(width: 32, height: 32)
-						.background(Color.duoSurface, in: Circle())
-				}
-				.accessibilityLabel("Settings")
+			Button(action: onHistoryTapped) {
+				Image(systemName: "clock.arrow.circlepath")
+					.font(.system(size: 14, weight: .semibold))
+					.foregroundStyle(Color.duoThemAccent)
+					.frame(width: 32, height: 32)
+					.background(Color.duoSurface, in: Circle())
 			}
+			.accessibilityLabel("Translation history")
 		}
 		.font(.system(size: 19, weight: .bold))
-		.accessibilityElement(children: .combine)
-		.accessibilityLabel("TalkTrans")
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the main header settings gear because it has no safe working destination
- keep the history button as the only header action
- remove header accessibility grouping so the history action remains individually accessible

## Verification
- mise x -- tuist build
- mise x -- tuist test
- git diff --check

```mermaid
flowchart TD
	Main[Main translation screen] -->|Tap history| History[History sheet]
	Main -. removed .-> Settings[Settings gear]
```
