### PR TITLE
Add reward gift button to header

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -469,14 +469,25 @@ private struct DuoHeaderView: View {
 
 			Spacer()
 
-			Button(action: onHistoryTapped) {
-				Image(systemName: "clock.arrow.circlepath")
-					.font(.system(size: 14, weight: .semibold))
-					.foregroundStyle(Color.duoThemAccent)
-					.frame(width: 32, height: 32)
-					.background(Color.duoSurface, in: Circle())
+			HStack(spacing: 8) {
+				Button(action: onHistoryTapped) {
+					Image(systemName: "clock.arrow.circlepath")
+						.font(.system(size: 14, weight: .semibold))
+						.foregroundStyle(Color.duoThemAccent)
+						.frame(width: 32, height: 32)
+						.background(Color.duoSurface, in: Circle())
+				}
+				.accessibilityLabel("Translation history")
+
+				WatchAdButton(
+					size: 32,
+					cornerRadius: 16,
+					iconSize: 14,
+					backgroundColor: .duoSurface,
+					backgroundOpacity: 1,
+					borderOpacity: 0
+				)
 			}
-			.accessibilityLabel("Translation history")
 		}
 		.font(.system(size: 19, weight: .bold))
 	}

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -12,6 +12,12 @@ struct WatchAdButton: View {
 	@EnvironmentObject private var adManager: SwiftUIAdManager
 	@EnvironmentObject private var analyticsManager: AnalyticsManager
 	var onAdFreeActivated: (() -> Void)?
+	var size: CGFloat = 52
+	var cornerRadius: CGFloat = 16
+	var iconSize: CGFloat = 18
+	var backgroundColor: Color = .duoYouAccent
+	var backgroundOpacity: Double = 0.14
+	var borderOpacity: Double = 0.24
 
 	@State private var showConfirmation = false
 
@@ -22,17 +28,18 @@ struct WatchAdButton: View {
 				showConfirmation = true
 			}) {
 				Image(systemName: "gift")
-					.font(.system(size: 18, weight: .semibold))
-					.frame(width: 52, height: 52)
-					.background(Color.duoYouAccent.opacity(0.14))
+					.font(.system(size: iconSize, weight: .semibold))
+					.frame(width: size, height: size)
+					.background(backgroundColor.opacity(backgroundOpacity))
 					.foregroundStyle(Color.duoYouAccentDeep)
-					.clipShape(.rect(cornerRadius: 16, style: .continuous))
+					.clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
 					.overlay(
-						RoundedRectangle(cornerRadius: 16, style: .continuous)
-							.stroke(Color.duoYouAccent.opacity(0.24), lineWidth: 1)
+						RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+							.stroke(Color.duoYouAccent.opacity(borderOpacity), lineWidth: 1)
 					)
 			}
 			.buttonStyle(.plain)
+			.accessibilityLabel("Remove ads for 1 hour")
 			.transition(.opacity.combined(with: .scale(scale: 0.8)))
 			.onAppear {
 				analyticsManager.logWatchAdPromptShown()


### PR DESCRIPTION
## Summary
- add the reward gift button in the former settings button slot on the main header
- present the reward flow directly from the main screen instead of a settings sheet
- make `WatchAdButton` configurable so it can render as a compact 32pt header control while keeping the existing 52pt default style

## Verification
- mise x -- tuist build
- mise x -- tuist test
- git diff --check

```mermaid
flowchart TD
	Main[Main translation screen] -->|Tap gift| Confirm[Reward confirmation]
	Confirm -->|Watch Ad| Reward[Rewarded ad]
	Reward -->|Completed| AdFree[Ad-free active]
	Main -->|Tap history| History[History sheet]
```

## Result
<img width="356" height="210" alt="스크린샷 2026-07-07 오전 10 33 18" src="https://github.com/user-attachments/assets/a8b1c0eb-7acb-4de3-a1de-fb0244f004ae" />
