### PR TITLE
Fix repeated translation trigger

### DIFF
--- a/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
+++ b/Projects/App/Sources/Screens/SpeechRecognitionScreen.swift
@@ -252,6 +252,7 @@ struct SpeechRecognitionScreen: View {
 
 			if let onProcess, let processTitle {
 				Button(action: {
+					commitCurrentRecognitionText()
 					viewModel.stopRecognition()
 					onProcess()
 				}) {
@@ -397,6 +398,13 @@ struct SpeechRecognitionScreen: View {
 		}
 
 		return recognitionPrefixText + " " + trimmedSegment
+	}
+
+	private func commitCurrentRecognitionText() {
+		let currentSegment = viewModel.recognizedText.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !currentSegment.isEmpty else { return }
+
+		text = combinedRecognitionText(newSegment: currentSegment)
 	}
 
 	#if targetEnvironment(simulator)

--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -21,6 +21,7 @@ struct TranslationScreen: View {
 	@State private var showAdFreeToast = false
 	@State private var lastHandledTranslationID: UUID?
 	@State private var isTableModePresented = false
+	@State private var lastTableModeTranslationInput = ""
 	@FocusState private var isInputFocused: Bool
 
 	private let topContentPadding: CGFloat = 12
@@ -171,6 +172,7 @@ struct TranslationScreen: View {
 
 						Button(action: {
 							isInputFocused = false
+							lastTableModeTranslationInput = viewModel.nativeText.trimmingCharacters(in: .whitespacesAndNewlines)
 							isTableModePresented = true
 						}) {
 							Image(systemName: "person.line.dotted.person.fill")
@@ -214,6 +216,13 @@ struct TranslationScreen: View {
 			reviewManager.show()
 			saveTranslationEntry()
 		}
+		.onChange(of: viewModel.nativeText) { _, _ in
+			translateTableModeInputIfNeeded()
+		}
+		.onChange(of: showSpeechRecognition) { _, isPresented in
+			guard !isPresented else { return }
+			translateTableModeInputIfNeeded()
+		}
 		.animation(.easeInOut, value: isTableModePresented)
 		.translationTask(viewModel.translationConfiguration) { [sessionBindingRequestID] session in
 			await viewModel.setTranslationSession(session, for: sessionBindingRequestID)
@@ -226,9 +235,7 @@ struct TranslationScreen: View {
 				targetLocale: viewModel.translatedLocale,
 				processTitle: "Use & translate",
 				onProcess: {
-					isInputFocused = false
-					showSpeechRecognition = false
-					viewModel.translate()
+					processRecognizedSpeech()
 				},
 				onCancel: {
 					showSpeechRecognition = false
@@ -263,6 +270,33 @@ struct TranslationScreen: View {
 		}
 		viewModel.nativeText = sourceText
 		viewModel.translatedText = translatedText
+	}
+
+	private func processRecognizedSpeech() {
+		isInputFocused = false
+		showSpeechRecognition = false
+
+		Task { @MainActor in
+			await Task.yield()
+			if isTableModePresented {
+				translateTableModeInputIfNeeded()
+			} else {
+				viewModel.translate()
+			}
+		}
+	}
+
+	private func translateTableModeInputIfNeeded() {
+		guard isTableModePresented else { return }
+		guard !showSpeechRecognition else { return }
+
+		let currentInput = viewModel.nativeText.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !currentInput.isEmpty else { return }
+		guard currentInput != lastTableModeTranslationInput else { return }
+		guard !viewModel.isTranslating else { return }
+
+		lastTableModeTranslationInput = currentInput
+		viewModel.translate()
 	}
 }
 

--- a/Projects/App/Sources/ViewModels/TranslationViewModel.swift
+++ b/Projects/App/Sources/ViewModels/TranslationViewModel.swift
@@ -145,10 +145,6 @@ class TranslationViewModel: ObservableObject {
 		activeTranslationRequestID = requestID
 		sessionBindingRequestID = requestID
 		
-		// Recreate TranslationSession configuration when translate button is pressed.
-		// Resetting to nil forces .translationTask to attach a fresh session,
-		// even when source/target language pair has not changed.
-		translationConfiguration = nil
 		createTranslationConfiguration(source: sourceLocale, target: targetLocale)
 	}
 	
@@ -241,12 +237,14 @@ class TranslationViewModel: ObservableObject {
 	}
 	
 	private func createTranslationConfiguration(source: Locale, target: Locale) {
-		// Create TranslationSession.Configuration for use with translationTask
-		var configuration = TranslationSession.Configuration()
+		// Reuse and invalidate the TranslationSession configuration so repeated
+		// translations with the same language pair trigger .translationTask again.
+		var configuration = translationConfiguration ?? TranslationSession.Configuration()
 		configuration.source = source.language
 		configuration.target = target.language
 
 		translationConfiguration = configuration
+		translationConfiguration?.invalidate()
 	}
 }
 


### PR DESCRIPTION
## Goal and success criteria
- Fix repeated translation requests when the input changes but the language pair stays the same.
- Ensure Speak Mode commits the latest recognized segment before translating.
- Ensure Table Mode translates after new speech input closes the speech sheet.

## User flow
```mermaid
flowchart TD
    A[User enters or speaks text] --> B[Commit latest input]
    B --> C{Table Mode open?}
    C -- Yes --> D[Detect changed table input]
    D --> E[Call translate]
    C -- No --> E
    E --> F[Reuse Translation configuration]
    F --> G[Invalidate configuration]
    G --> H[translationTask runs and updates output]
```

## Review notes
- Replaces the old nil-reset translation trigger with configuration reuse + invalidate for same language-pair retries.
- Adds final speech transcript commit before the Use & translate callback.
- Adds Table Mode input-change gating to avoid duplicate translates for unchanged text.

## Verification
- ✅ `mise x -- tuist test`
- ✅ `git diff --check`
- ⚠️ Manual Apple Translation runtime verification requires a real device; simulator cannot validate Translation framework behavior.

## Risks and mitigations
- Risk: repeated invalidation behavior depends on Apple Translation framework semantics. Mitigation: uses documented invalidate pattern and keeps request-id execution gate.
- Risk: duplicate Table Mode translates. Mitigation: tracks trimmed last translated Table Mode input and checks `isTranslating`.
