### PR TITLE
Fix listening session reset on reopen

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -22,6 +22,7 @@ struct TranslationScreen: View {
 	@State private var lastHandledTranslationID: UUID?
 	@State private var isTableModePresented = false
 	@State private var lastTableModeTranslationInput = ""
+	@State private var speechDraftText = ""
 	@FocusState private var isInputFocused: Bool
 
 	private let topContentPadding: CGFloat = 12
@@ -58,7 +59,7 @@ struct TranslationScreen: View {
 						isTableModePresented = false
 					},
 					onSpeakToReply: {
-						showSpeechRecognition = true
+						presentSpeechRecognition()
 					},
 					onSwap: {
 						viewModel.swapLanguages()
@@ -77,7 +78,7 @@ struct TranslationScreen: View {
 					DuoModeSelectorView(
 						isSpeechSelected: showSpeechRecognition,
 						onTypeTapped: { showSpeechRecognition = false },
-						onSpeakTapped: { showSpeechRecognition = true }
+						onSpeakTapped: { presentSpeechRecognition() }
 					)
 						.padding(.horizontal, 16)
 
@@ -230,7 +231,7 @@ struct TranslationScreen: View {
 		.fullScreenCover(isPresented: $showSpeechRecognition) {
 			SpeechRecognitionScreen(
 				viewModel: speechViewModel,
-				text: $viewModel.nativeText,
+				text: $speechDraftText,
 				sourceLocale: viewModel.nativeLocale,
 				targetLocale: viewModel.translatedLocale,
 				processTitle: "Use & translate",
@@ -272,8 +273,15 @@ struct TranslationScreen: View {
 		viewModel.translatedText = translatedText
 	}
 
+	private func presentSpeechRecognition() {
+		isInputFocused = false
+		speechDraftText = ""
+		showSpeechRecognition = true
+	}
+
 	private func processRecognizedSpeech() {
 		isInputFocused = false
+		viewModel.nativeText = speechDraftText
 		showSpeechRecognition = false
 
 		Task { @MainActor in


### PR DESCRIPTION
## Goal and success criteria
- Reset the listening screen each time it is opened.
- Prevent stale recognized text from appearing on reopen.
- Keep main input unchanged when the user cancels listening.

## User flow
```mermaid
flowchart TD
    A[Open listening screen] --> B[Reset speech draft]
    B --> C[Recognize into draft only]
    C --> D{User action}
    D -- Use & translate --> E[Copy draft to main input]
    D -- Cancel --> F[Discard draft]
```

## Changes
- Added a dedicated `speechDraftText` for the listening full-screen session.
- Route Speak and Table Mode reply entry through `presentSpeechRecognition()`.
- Copy draft text back to `viewModel.nativeText` only when processing.

## Verification
- ✅ `mise x -- tuist test`
- ✅ `git diff --check`
