### PR TITLE
Fix Table Mode center control spacing

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -402,7 +402,7 @@ private struct DuoTableModePanel: View {
 				let textHeightRatio = onSpeakToReply == nil ? 0.48 : 0.44
 				let textMaxHeight = max(150, proxy.size.height * textHeightRatio)
 				let textFontSize: CGFloat = hasLongText ? (isUpsideDown ? 34 : 28) : (isUpsideDown ? 42 : 34)
-				let topSpacerHeight: CGFloat = usesGlassInputLayout ? 16 : (hasLongText ? 24 : 42)
+				let topSpacerHeight: CGFloat = usesGlassInputLayout ? 42 : (hasLongText ? 24 : 42)
 				let bottomSpacerHeight: CGFloat = usesGlassInputLayout ? 0 : (hasLongText ? 28 : (isUpsideDown ? 82 : 62))
 				let inputBottomFadeLength: CGFloat = usesGlassInputLayout ? 60 : 44
 


### PR DESCRIPTION
## Summary
- align the lower YOU language pill spacing with the upper THEM pill spacing from the center divider
- move the YOU pill below the center swap button's touch/visual area to prevent overlap

## User flow
```mermaid
flowchart TD
    A[Open Table Mode] --> B[Center swap control appears]
    B --> C[THEM pill above center]
    B --> D[YOU pill below center]
    C --> E[Equal visual spacing from center]
    D --> E
    E --> F[No overlap between swap and YOU pill]
```

## Verification
- [x] Visual review on iPhone 11 Pro Max simulator: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-center-spacing-fix.png
- [x] `mise x -- tuist build`
- [x] `mise x -- tuist test`
- [x] `git diff --check`

## Release / rollback
- UI-only spacing change in Table Mode.
- Roll back by reverting this PR if center spacing regresses on other device sizes.

## Result
<img width="351" height="246" alt="스크린샷 2026-07-08 오전 10 00 55" src="https://github.com/user-attachments/assets/e264416f-b294-4ec7-ab64-62f968d20e3c" />
