### PR TITLE
Add upper Table Mode center fade

### DIFF
--- a/Projects/App/Sources/Screens/TranslationScreen.swift
+++ b/Projects/App/Sources/Screens/TranslationScreen.swift
@@ -398,16 +398,16 @@ private struct DuoTableModePanel: View {
 			GeometryReader { proxy in
 				let hasLongText = displayText.count > 80
 				let isInputPanel = onSpeakToReply != nil
-				let usesGlassInputLayout = isInputPanel && supportsLiquidGlass
+				let usesCenterFadeLayout = supportsLiquidGlass && (isInputPanel || isUpsideDown)
 				let textHeightRatio = onSpeakToReply == nil ? 0.48 : 0.44
 				let textMaxHeight = max(150, proxy.size.height * textHeightRatio)
 				let textFontSize: CGFloat = hasLongText ? (isUpsideDown ? 34 : 28) : (isUpsideDown ? 42 : 34)
-				let topSpacerHeight: CGFloat = usesGlassInputLayout ? 42 : (hasLongText ? 24 : 42)
-				let bottomSpacerHeight: CGFloat = usesGlassInputLayout ? 0 : (hasLongText ? 28 : (isUpsideDown ? 82 : 62))
-				let inputBottomFadeLength: CGFloat = usesGlassInputLayout ? 60 : 44
+				let topSpacerHeight: CGFloat = usesCenterFadeLayout ? 42 : (hasLongText ? 24 : 42)
+				let bottomSpacerHeight: CGFloat = usesCenterFadeLayout ? 0 : (hasLongText ? 28 : (isUpsideDown ? 82 : 62))
+				let bottomFadeLength: CGFloat = usesCenterFadeLayout && isInputPanel ? 60 : 44
 
 				ZStack(alignment: .bottom) {
-					if usesGlassInputLayout {
+					if usesCenterFadeLayout {
 						ScrollView(.vertical) {
 							Text(displayText)
 								.font(.system(size: textFontSize, weight: .bold, design: .rounded))
@@ -421,8 +421,8 @@ private struct DuoTableModePanel: View {
 						}
 						.frame(maxHeight: .infinity)
 						.contentMargins(.top, 112, for: .scrollContent)
-						.contentMargins(.bottom, 96, for: .scrollContent)
-						.scrollEdgeFade(isEnabled: true, topLength: 116, bottomLength: inputBottomFadeLength)
+						.contentMargins(.bottom, isInputPanel ? 96 : 44, for: .scrollContent)
+						.scrollEdgeFade(isEnabled: true, topLength: 116, bottomLength: bottomFadeLength)
 						.scrollBounceBehavior(.basedOnSize)
 						.accessibilityLabel(displayText)
 
@@ -465,7 +465,7 @@ private struct DuoTableModePanel: View {
 							}
 							.frame(maxHeight: textMaxHeight)
 							.contentMargins(.bottom, isInputPanel ? 72 : 0, for: .scrollContent)
-							.scrollEdgeFade(isEnabled: isInputPanel, topLength: 0, bottomLength: inputBottomFadeLength)
+							.scrollEdgeFade(isEnabled: isInputPanel, topLength: 0, bottomLength: bottomFadeLength)
 							.scrollBounceBehavior(.basedOnSize)
 							.accessibilityLabel(displayText)
 


### PR DESCRIPTION
## Summary
- apply the same center-edge scroll fade layout to the upper THEM panel as the input panel
- keep the THEM language pill overlaid above the center divider so translated text can fade behind it instead of hard clipping
- preserve existing input-side bottom fade and Speak button margin behavior

## User flow
```mermaid
flowchart TD
    A[Open Table Mode] --> B[Upper THEM panel]
    B --> C[Translated text scrolls/fills panel]
    C --> D[Text approaches center language pill]
    D --> E[Text fades under THEM pill near center]
    A --> F[Lower YOU panel keeps existing fade]
```

## Verification
- [x] Visual review on iPhone 11 Pro Max simulator: /var/folders/6x/l8h411bn30xd7f7ptkpc48mr0000gn/T/opencode/table-mode-upper-center-fade.png
- [x] `mise x -- tuist build`
- [x] `mise x -- tuist test`
- [x] `git diff --check`

## Release / rollback
- UI-only Table Mode layout/masking change.
- Roll back by reverting this PR if translated text positioning regresses.

## Result
<img width="365" height="399" alt="스크린샷 2026-07-08 오전 10 43 34" src="https://github.com/user-attachments/assets/fc6eb227-1f27-4bb7-9840-bfc8ba71b528" />
